### PR TITLE
Test/#20 회원가입 및 로그인 테스트 코드 작성, 리팩토링

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/dto/AuthenticatedUser.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/dto/AuthenticatedUser.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @Getter
 public class AuthenticatedUser {
 
-	private Long userId;
-	private Role role;
+	private final Long userId;
+	private final Role role;
 
 	public AuthenticatedUser(Long userId, Role role) {
 		this.userId = userId;

--- a/haul-be/src/main/java/com/hansalchai/haul/user/controller/UsersController.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/controller/UsersController.java
@@ -20,7 +20,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@RequestMapping("api/v1/users")
+@RequestMapping("/api/v1/users")
 @RestController
 public class UsersController {
 

--- a/haul-be/src/main/java/com/hansalchai/haul/user/dto/CustomerSignUpDto.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/dto/CustomerSignUpDto.java
@@ -10,16 +10,16 @@ import lombok.Getter;
 public class CustomerSignUpDto {
 
 	@NotNull(message = "이름은 null일 수 없습니다.")
-	private String name;
+	private final String name;
 
 	@NotNull(message = "전화번호는 null일 수 없습니다.")
-	private String tel;
+	private final String tel;
 
 	@NotNull(message = "비밀번호는 null일 수 없습니다.")
-	private String password;
+	private final String password;
 
 	@NotNull(message = "이메일은 null일 수 없습니다.")
-	private String email;
+	private final String email;
 
 	public CustomerSignUpDto(String name, String tel, String password, String email) {
 		this.name = name;

--- a/haul-be/src/main/java/com/hansalchai/haul/user/dto/CustomerSignUpDto.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/dto/CustomerSignUpDto.java
@@ -21,6 +21,13 @@ public class CustomerSignUpDto {
 	@NotNull(message = "이메일은 null일 수 없습니다.")
 	private String email;
 
+	public CustomerSignUpDto(String name, String tel, String password, String email) {
+		this.name = name;
+		this.tel = tel;
+		this.password = password;
+		this.email = email;
+	}
+
 	public Users toEntity() {
 		return Users.builder()
 			.name(name)

--- a/haul-be/src/main/java/com/hansalchai/haul/user/dto/UserLoginDto.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/dto/UserLoginDto.java
@@ -1,12 +1,16 @@
 package com.hansalchai.haul.user.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class UserLoginDto {
 
-	private String tel;
-	private String password;
+	@NotNull(message = "전화번호(아이디)는 null일 수 없습니다.")
+	private final String tel;
+
+	@NotNull(message = "비밀번호는 null일 수 없습니다.")
+	private final String password;
 
 
 	public UserLoginDto(String tel, String password) {

--- a/haul-be/src/main/java/com/hansalchai/haul/user/dto/UserLoginDto.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/dto/UserLoginDto.java
@@ -7,4 +7,10 @@ public class UserLoginDto {
 
 	private String tel;
 	private String password;
+
+
+	public UserLoginDto(String tel, String password) {
+		this.tel = tel;
+		this.password = password;
+	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/user/service/UsersService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/service/UsersService.java
@@ -21,13 +21,14 @@ public class UsersService {
 	private final UsersRepository usersRepository;
 
 	@Transactional
-	public void signUp(CustomerSignUpDto signUpDto) {
+	public Long signUp(CustomerSignUpDto signUpDto) {
 		//중복 회원가입 검증
 		String tel = signUpDto.getTel();
 		if (usersRepository.findByTel(tel).isPresent()) {
 			throw new IllegalArgumentException("이미 가입된 전화번호입니다.");
 		}
-		usersRepository.save(signUpDto.toEntity());
+
+		return usersRepository.save(signUpDto.toEntity()).getUserId();
 	}
 
 	@Transactional

--- a/haul-be/src/test/java/com/hansalchai/haul/user/controller/UsersControllerTest.java
+++ b/haul-be/src/test/java/com/hansalchai/haul/user/controller/UsersControllerTest.java
@@ -1,0 +1,41 @@
+package com.hansalchai.haul.user.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hansalchai.haul.user.dto.CustomerSignUpDto;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UsersControllerTest {
+
+	@Autowired MockMvc mockMvc;
+	@Autowired ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("회원가입 테스트")
+	void signUp() throws Exception {
+
+		//given
+		String content = objectMapper.writeValueAsString(
+			new CustomerSignUpDto("haul", "01012341234", "password", "haul@gmail.com"));
+
+		//when, then
+		mockMvc.perform(post("/api/v1/users/sign-up")
+				.content(content)
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+}

--- a/haul-be/src/test/java/com/hansalchai/haul/user/controller/UsersControllerTest.java
+++ b/haul-be/src/test/java/com/hansalchai/haul/user/controller/UsersControllerTest.java
@@ -13,14 +13,23 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hansalchai.haul.common.auth.constants.Role;
 import com.hansalchai.haul.user.dto.CustomerSignUpDto;
+import com.hansalchai.haul.user.dto.UserLoginDto;
+import com.hansalchai.haul.user.entity.Users;
+import com.hansalchai.haul.user.repository.UsersRepository;
+
+import jakarta.transaction.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 class UsersControllerTest {
 
 	@Autowired MockMvc mockMvc;
 	@Autowired ObjectMapper objectMapper;
+
+	@Autowired UsersRepository usersRepository;
 
 	@Test
 	@DisplayName("회원가입 테스트")
@@ -36,6 +45,33 @@ class UsersControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("로그인 테스트")
+	void signIn() throws Exception {
+
+		//given
+		Users user = Users.builder()
+			.name("haul")
+			.tel("01012341234")
+			.password("password")
+			.email("haul@gmail.com")
+			.role(Role.CUSTOMER)
+			.build();
+		usersRepository.save(user);
+
+		//when, then
+		String content = objectMapper.writeValueAsString(new UserLoginDto("01012341234", "password"));
+
+		mockMvc.perform(post("/api/v1/users/sign-in")
+				.content(content)
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.accessToken").exists())
+			.andExpect(jsonPath("$.data.refreshToken").exists())
 			.andDo(print());
 	}
 }

--- a/haul-be/src/test/java/com/hansalchai/haul/user/service/UsersServiceTest.java
+++ b/haul-be/src/test/java/com/hansalchai/haul/user/service/UsersServiceTest.java
@@ -1,0 +1,59 @@
+package com.hansalchai.haul.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.hansalchai.haul.user.dto.CustomerSignUpDto;
+import com.hansalchai.haul.user.entity.Users;
+import com.hansalchai.haul.user.repository.UsersRepository;
+
+import jakarta.transaction.Transactional;
+
+@Transactional
+@SpringBootTest
+class UsersServiceTest {
+
+	@Autowired UsersService usersService;
+	@Autowired UsersRepository usersRepository;
+
+	@Test
+	@DisplayName("회원가입 성공")
+	void signUpSuccessTest() {
+
+		//given
+		CustomerSignUpDto signUpDto
+			= new CustomerSignUpDto("haul", "01012341234", "password", "haul@gmail.com");
+
+		//when
+		Long userId = usersService.signUp(signUpDto);
+
+		//then
+		Users user = usersRepository.findById(userId)
+			.orElseThrow(IllegalArgumentException::new);
+
+		assertThat(user.getName()).isEqualTo("haul");
+		assertThat(user.getTel()).isEqualTo("01012341234");
+		assertThat(user.getEmail()).isEqualTo("haul@gmail.com");
+	}
+
+	@Test
+	@DisplayName("회원가입 실패 - 중복 전화번호 검증")
+	void signUpFailTest() {
+
+		//given
+		CustomerSignUpDto signUpDto1
+			= new CustomerSignUpDto("haul1", "01012341234", "password", "haul1@gmail.com");
+		CustomerSignUpDto signUpDto2
+			= new CustomerSignUpDto("haul2", "01012341234", "password", "haul2@gmail.com");
+
+		//when, then
+		usersService.signUp(signUpDto1); // 성공
+		assertThatThrownBy(() -> usersService.signUp(signUpDto2)) //중복 전화번호로 가입 -> 예외 발생
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("이미 가입된 전화번호입니다.");
+	}
+}


### PR DESCRIPTION
## 반영 브랜치
ex) test/#20-auth -> BE_dev

## PR 요약
- 회원가입, 로그인 기능에 대한 테스트 코드 작성
- 로그인 dto 유효성 검증
- 회원가입, 로그인에 사용되는 dto를 불변 객체로 수정

## PR 설명
- 컨트롤러 단의 테스트 코드 작성(`UsersControllerTest`)
- 서비스 단의 테스트 코드 작성(`UsersServiceTest`)
- dto 필드에 `@NotNull`을 붙여 입력이 null인 경우, 400 Bad Request를 응답함
- 인증에 사용되는 객체의 필드에 `final` 키워드 추가 -> 불변 객체로 만들어 값을 수정할 수 없게 함