### PR TITLE
feat : aws s3 세팅 및 이미지 조회 기능 구현

### DIFF
--- a/haul-be/build.gradle
+++ b/haul-be/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	//s3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/haul-be/src/main/java/com/hansalchai/haul/common/config/AwsS3Config.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/config/AwsS3Config.java
@@ -1,0 +1,36 @@
+package com.hansalchai.haul.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class AwsS3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public BasicAWSCredentials basicAWSCredentials() {
+		return new BasicAWSCredentials(accessKey, secretKey);
+	}
+
+	@Bean
+	public AmazonS3 amazonS3(BasicAWSCredentials basicAWSCredentials) {
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+			.build();
+	}
+}

--- a/haul-be/src/main/java/com/hansalchai/haul/common/utils/S3Util.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/utils/S3Util.java
@@ -1,0 +1,22 @@
+package com.hansalchai.haul.common.utils;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.s3.AmazonS3;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class S3Util {
+
+	private final AmazonS3 amazonS3;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	public String getImage(String fileName) {
+		return amazonS3.getUrl(bucket, fileName).toString();
+	}
+}


### PR DESCRIPTION
## 반영 브랜치
ex) config/aws-s3 -> BE_dev

## PR 요약
- aws s3 설정
- 이미지 조회 기능 구현

## PR 설명
프로필 이미지, 차 이미지 조회를 위한 aws s3를 세팅했다. 
`S3Util의 getImage()`로 이미지를 조회할 수 있다.