### PR TITLE
Hotfix/#81 preflight request의 CORS 에러 해결

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/JwtValidationFilter.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/JwtValidationFilter.java
@@ -41,6 +41,12 @@ public class JwtValidationFilter implements Filter {
 		HttpServletRequest httpServletRequest = (HttpServletRequest) request;
 		HttpServletResponse httpServletResponse = (HttpServletResponse) response;
 
+		//http method가 preflight이면 토큰 유효성을 검증하지 않는다
+		if (isPrefilghtRequest(httpServletRequest)) {
+			chain.doFilter(request, response);
+			return;
+		}
+
 		// 토큰 유효성을 검증하지 않아도 되는 경우
 		if (whiteListCheck(httpServletRequest.getRequestURI())) {
 			chain.doFilter(request, response);
@@ -64,6 +70,13 @@ public class JwtValidationFilter implements Filter {
 		}
 
 		chain.doFilter(request, response);
+	}
+
+	private boolean isPrefilghtRequest(HttpServletRequest request) {
+		if (request.getMethod().equals("OPTIONS")) {
+			return true;
+		}
+		return false;
 	}
 
 	private boolean whiteListCheck(String uri) {

--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/dto/AuthenticatedUser.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/dto/AuthenticatedUser.java
@@ -4,12 +4,14 @@ import com.hansalchai.haul.common.auth.constants.Role;
 import com.hansalchai.haul.user.entity.Users;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class AuthenticatedUser {
 
-	private final Long userId;
-	private final Role role;
+	private Long userId;
+	private Role role;
 
 	public AuthenticatedUser(Long userId, Role role) {
 		this.userId = userId;


### PR DESCRIPTION
## 반영 브랜치
ex) hotfix/#81-fix-cors-error -> BE_dev

## PR 요약
- AuthenticatedUser 클래스에 기본 생성자 추가
- preflight request의 CORS 에러 해결

## PR 설명
- AuthenticatedUser 클래스에 기본 생성자가 없어 오류가 발생했다. 따라서 final 키워드를 삭제하고 기본 생성자를 추가해 해결했다.
- OPTIONS 요청에서는 사용자 인증을 하지 않아야 하는데 기존 코드에선 토큰 유효성 검증을 하고 있어 CORS 에러가 발생했다. 따라서 http method가 OPTIONS인 경우 인터셉터에서 사용자 인증을 하지 않도록 토큰 검증 필터를 수정했다.

## ETC
Close #81 