### PR TITLE
Feat/#51 [기사] 오더 승인 api 구현

### DIFF
--- a/haul-be/build.gradle
+++ b/haul-be/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
 	//s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	//sms
+	implementation 'net.nurigo:sdk:4.3.0'
 }
 
 tasks.named('test') {

--- a/haul-be/src/main/java/com/hansalchai/haul/common/config/SmsUtil.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/config/SmsUtil.java
@@ -1,0 +1,46 @@
+package com.hansalchai.haul.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class SmsUtil {
+
+	@Value("${coolsms.api.key}")
+	private String apiKey;
+
+	@Value("${coolsms.api.secret}")
+	private String apiSecretKey;
+
+	@Value("${coolsms.from}")
+	private String from;
+
+	private DefaultMessageService messageService;
+
+	@PostConstruct
+	private void init(){
+		messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecretKey, "https://api.coolsms.co.kr");
+	}
+
+	// 단일 메시지 발송
+	public SingleMessageSentResponse send(String to, String reservationNumber) {
+		Message message = new Message();
+		message.setFrom(from);
+		message.setTo(to);
+		message.setText("기사 배정이 완료되었습니다. 앱에서 확인해주세요\n" + "예약번호 : " + reservationNumber);
+
+		SingleMessageSentResponse response = this.messageService.sendOne(new SingleMessageSendingRequest(message));
+		log.info("sms 전송 내역 : {}", response);
+		return response;
+	}
+}

--- a/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
@@ -1,0 +1,34 @@
+package com.hansalchai.haul.order.controller;
+
+import static com.hansalchai.haul.common.auth.jwt.JwtProvider.*;
+import static com.hansalchai.haul.common.utils.ApiResponse.*;
+import static com.hansalchai.haul.common.utils.SuccessCode.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hansalchai.haul.common.auth.dto.AuthenticatedUser;
+import com.hansalchai.haul.order.dto.ApproveRequestDto;
+import com.hansalchai.haul.order.service.OrderService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/orders")
+@RestController
+public class OrderController {
+
+	private final OrderService orderService;
+
+	@PutMapping("/approve")
+	public ResponseEntity approveOrder(HttpServletRequest request, @Valid @RequestBody ApproveRequestDto approveRequestDto) {
+		AuthenticatedUser auth = (AuthenticatedUser)request.getAttribute(AUTHENTICATE_USER);
+		orderService.approve(auth.getUserId(), approveRequestDto);
+		return ResponseEntity.ok(success(GET_SUCCESS, null));
+	}
+}

--- a/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
@@ -5,7 +5,7 @@ import static com.hansalchai.haul.common.utils.ApiResponse.*;
 import static com.hansalchai.haul.common.utils.SuccessCode.*;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,8 +25,10 @@ public class OrderController {
 
 	private final OrderService orderService;
 
-	@PutMapping("/approve")
-	public ResponseEntity approveOrder(HttpServletRequest request, @Valid @RequestBody ApproveRequestDto approveRequestDto) {
+	@PatchMapping("/approve")
+	public ResponseEntity approveOrder(HttpServletRequest request,
+		@Valid @RequestBody ApproveRequestDto approveRequestDto) {
+
 		AuthenticatedUser auth = (AuthenticatedUser)request.getAttribute(AUTHENTICATE_USER);
 		orderService.approve(auth.getUserId(), approveRequestDto);
 		return ResponseEntity.ok(success(GET_SUCCESS, null));

--- a/haul-be/src/main/java/com/hansalchai/haul/order/dto/ApproveRequestDto.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/dto/ApproveRequestDto.java
@@ -1,0 +1,14 @@
+package com.hansalchai.haul.order.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ApproveRequestDto {
+
+	@NotNull(message = "차 id는 null일 수 없다.")
+	private Long carId;
+
+	@NotNull(message = "예약 id는 null일 수 없다.")
+	private Long reservationId;
+}

--- a/haul-be/src/main/java/com/hansalchai/haul/order/dto/ApproveRequestDto.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/dto/ApproveRequestDto.java
@@ -6,9 +6,6 @@ import lombok.Getter;
 @Getter
 public class ApproveRequestDto {
 
-	@NotNull(message = "차 id는 null일 수 없다.")
-	private Long carId;
-
 	@NotNull(message = "예약 id는 null일 수 없다.")
 	private Long reservationId;
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -1,0 +1,37 @@
+package com.hansalchai.haul.order.service;
+
+import org.springframework.stereotype.Service;
+
+import com.hansalchai.haul.order.dto.ApproveRequestDto;
+import com.hansalchai.haul.owner.entity.Owner;
+import com.hansalchai.haul.owner.repository.OwnerRepository;
+import com.hansalchai.haul.reservation.entity.Reservation;
+import com.hansalchai.haul.reservation.repository.ReservationRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class OrderService {
+
+	private final ReservationRepository reservationRepository;
+	private final OwnerRepository ownerRepository;
+
+	@Transactional
+	public void approve(Long driverId, ApproveRequestDto approveRequestDto) {
+
+		// 1. 예약 정보 가져오기
+		Reservation reservation = reservationRepository.findById(approveRequestDto.getReservationId())
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약번호입니다."));
+
+		// 2. 기사 정보 가져오기
+		Owner owner = ownerRepository.findByDriverIdAndCarId(driverId, approveRequestDto.getCarId())
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 owner입니다."));
+
+		// 3. 예약에 기사 배정 정보 저장
+		reservation.setDriver(owner);
+
+		// TODO : 해당 예약을 만든 고객에게 sms로 기사 배정 정보 전송
+	}
+}

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -2,6 +2,7 @@ package com.hansalchai.haul.order.service;
 
 import org.springframework.stereotype.Service;
 
+import com.hansalchai.haul.common.config.SmsUtil;
 import com.hansalchai.haul.order.dto.ApproveRequestDto;
 import com.hansalchai.haul.owner.entity.Owner;
 import com.hansalchai.haul.owner.repository.OwnerRepository;
@@ -17,6 +18,7 @@ public class OrderService {
 
 	private final ReservationRepository reservationRepository;
 	private final OwnerRepository ownerRepository;
+	private final SmsUtil smsUtil;
 
 	@Transactional
 	public void approve(Long driverId, ApproveRequestDto approveRequestDto) {
@@ -32,6 +34,9 @@ public class OrderService {
 		// 3. 예약에 기사 배정 정보 저장
 		reservation.setDriver(owner);
 
-		// TODO : 해당 예약을 만든 고객에게 sms로 기사 배정 정보 전송
+		// 4. 배정 알림을 고객에게 sms로 전송
+		String customerTel = reservation.getUser().getTel();
+		String reservationNumber = reservation.getNumber();
+		smsUtil.send(customerTel, reservationNumber);
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -28,7 +28,7 @@ public class OrderService {
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약번호입니다."));
 
 		// 2. 기사 정보 가져오기
-		Owner owner = ownerRepository.findByDriverIdAndCarId(driverId, approveRequestDto.getCarId())
+		Owner owner = ownerRepository.findByDriverId(driverId)
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 owner입니다."));
 
 		// 3. 예약에 기사 배정 정보 저장

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -1,5 +1,7 @@
 package com.hansalchai.haul.order.service;
 
+import static com.hansalchai.haul.reservation.constants.TransportStatus.*;
+
 import org.springframework.stereotype.Service;
 
 import com.hansalchai.haul.common.config.SmsUtil;
@@ -7,6 +9,7 @@ import com.hansalchai.haul.order.dto.ApproveRequestDto;
 import com.hansalchai.haul.owner.entity.Owner;
 import com.hansalchai.haul.owner.repository.OwnerRepository;
 import com.hansalchai.haul.reservation.entity.Reservation;
+import com.hansalchai.haul.reservation.entity.Transport;
 import com.hansalchai.haul.reservation.repository.ReservationRepository;
 
 import jakarta.transaction.Transactional;
@@ -31,8 +34,10 @@ public class OrderService {
 		Owner owner = ownerRepository.findByDriverId(driverId)
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 owner입니다."));
 
-		// 3. 예약에 기사 배정 정보 저장
+		// 3. 예약에 기사 배정 정보 저장, 운송 상태를 '운송 전'으로 변경
 		reservation.setDriver(owner);
+		Transport transport = reservation.getTransport();
+		transport.updateTransportStatus(NOT_STARTED);
 
 		// 4. 배정 알림을 고객에게 sms로 전송
 		String customerTel = reservation.getUser().getTel();

--- a/haul-be/src/main/java/com/hansalchai/haul/owner/repository/OwnerRepository.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/owner/repository/OwnerRepository.java
@@ -1,9 +1,15 @@
 package com.hansalchai.haul.owner.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.hansalchai.haul.owner.entity.Owner;
 
 public interface OwnerRepository extends JpaRepository<Owner, Long> {
 
+	@Query("select o from Owner o where o.user.userId = :driverId and o.car.carId = :carId")
+	Optional<Owner> findByDriverIdAndCarId(@Param("driverId") Long driverId, @Param("carId") Long carId);
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/owner/repository/OwnerRepository.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/owner/repository/OwnerRepository.java
@@ -10,6 +10,6 @@ import com.hansalchai.haul.owner.entity.Owner;
 
 public interface OwnerRepository extends JpaRepository<Owner, Long> {
 
-	@Query("select o from Owner o where o.user.userId = :driverId and o.car.carId = :carId")
-	Optional<Owner> findByDriverIdAndCarId(@Param("driverId") Long driverId, @Param("carId") Long carId);
+	@Query("select o from Owner o where o.user.userId = :driverId")
+	Optional<Owner> findByDriverId(@Param("driverId") Long driverId);
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/entity/Reservation.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/entity/Reservation.java
@@ -8,7 +8,6 @@ import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.validator.constraints.Range;
 
 import com.hansalchai.haul.car.entity.Car;
-import com.hansalchai.haul.common.auth.constants.Role;
 import com.hansalchai.haul.common.utils.BaseTime;
 import com.hansalchai.haul.owner.entity.Owner;
 import com.hansalchai.haul.user.entity.Users;
@@ -117,5 +116,9 @@ public class Reservation extends BaseTime {
 				.distance(distance)
 				.count(count)
 				.build();
+	}
+
+	public void setDriver(Owner owner) {
+		this.owner = owner;
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/entity/Transport.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/entity/Transport.java
@@ -65,5 +65,9 @@ public class Transport extends BaseTime {
 	public void changeStatusReserved(){
 		this.transportStatus = TransportStatus.PENDING;
 	}
+
+	public void updateTransportStatus(TransportStatus transportStatus) {
+		this.transportStatus = transportStatus;
+	}
 }
 


### PR DESCRIPTION
## 반영 브랜치
ex) feat/#51-approve-order -> BE_dev

## PR 요약
기사의 오더 승인 api 구현

## PR 설명
- sms 전송에 Coolsms 이용
- ApproveRequestDto의 carId : 기사인 owner 객체를 예약에 저장하는 방식으로 오더 승인 기능을 구현했는데 기사 객체를 찾을 때 필요함
- SmsUtil의 init()의 `@PostConstruct` : `@Value`값을 가져온 다음 init()이 실행되게 함

## ETC
추후 동시성 처리 필요