### PR TITLE
Fix/#102 프론트 배포 url에 대한 cors error 해결

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/config/WebConfig.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/config/WebConfig.java
@@ -4,13 +4,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
 @Configuration
 @EnableWebMvc
 public class WebConfig implements WebMvcConfigurer {
+
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins("http://localhost:5173")
+			.allowedOrigins("http://localhost:5173", "https://haul.pages.dev")
 			.allowedMethods("*")
 			.allowedHeaders("*")
 			.exposedHeaders("*");


### PR DESCRIPTION
## 반영 브랜치
ex) fix/#102-cors-error -> BE_dev

## PR 요약
프론트 배포 url에 대한 cors error 해결

## PR 설명
WebConfig의 allowedOrigins에 프론트 배포 url을 추가했다.

## ETC
Close #102 