### PR TITLE
fix: 지도 출력되지 않는 버그 수정

### DIFF
--- a/haul-fe/index.html
+++ b/haul-fe/index.html
@@ -61,7 +61,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
-    <script type="text/javascript" defer src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_MAP_KEY%&autoload=false&libraries=services"></script>
-    <script type="text/javascript" defer src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
-  </body>
+     </body>
 </html>

--- a/haul-fe/src/components/Map/RouteMap/RouteMap.jsx
+++ b/haul-fe/src/components/Map/RouteMap/RouteMap.jsx
@@ -1,6 +1,23 @@
+/* eslint-disable no-undef */
 import { useEffect } from "react";
 
 const restApiKey = import.meta.env.VITE_KAKAO_MAP_REST_KEY;
+
+const loadKakaoMaps = drawdirection => {
+  const script = document.createElement("script");
+  script.type = "text/javascript";
+  script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${
+    import.meta.env.VITE_KAKAO_MAP_KEY
+  }&autoload=false&libraries=services`;
+
+  script.onload = () => {
+    window.kakao.maps.load(() => {
+      drawdirection();
+    });
+  };
+
+  document.head.appendChild(script);
+};
 
 // 지도, 출발지, 도착지 위도를 찍으면 지도에 경로를 그려주는 함수
 async function getCarDirection({ kakaoMap, srcCoordinate, dstCoordinate }) {
@@ -51,6 +68,7 @@ async function getCarDirection({ kakaoMap, srcCoordinate, dstCoordinate }) {
       bounds.extend(linePath[i]);
     }
     kakaoMap.setBounds(bounds);
+
     const polyline = new kakao.maps.Polyline({
       path: linePath,
       strokeWeight: 5,
@@ -64,10 +82,9 @@ async function getCarDirection({ kakaoMap, srcCoordinate, dstCoordinate }) {
   }
 }
 
-const drawdirection = (origin, destination) => {
-  const mapContainer = document.getElementById("map");
-
-  window.kakao.maps.load(() => {
+const RouteMap = ({ origin, destination }) => {
+  const drawdirection = () => {
+    const mapContainer = document.getElementById("map");
     const mapOptions = {
       center: new kakao.maps.LatLng(origin.lat, origin.lng),
       level: 10
@@ -103,12 +120,10 @@ const drawdirection = (origin, destination) => {
       srcCoordinate: origin,
       dstCoordinate: destination
     });
-  });
-};
+  };
 
-const RouteMap = ({ origin, destination }) => {
   useEffect(() => {
-    drawdirection(origin, destination);
+    loadKakaoMaps(drawdirection);
   }, []);
 
   return (

--- a/haul-fe/src/components/Map/SearchMap/SearchMap.jsx
+++ b/haul-fe/src/components/Map/SearchMap/SearchMap.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import { useState, useEffect } from "react";
 import Input from "../../Input/Input.jsx";
 import Margin from "../../Margin/Margin.jsx";
@@ -22,8 +23,47 @@ const SearchMap = ({
     initialAddressFun(beforeName, beforeAddress)
   );
 
+  const [isKakaoMapLoaded, setIsKakaoMapLoaded] = useState(false);
+  const [isPostcodeLoaded, setIsPostcodeLoaded] = useState(false);
+
+  const loadKakaoMaps = () => {
+    const script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${
+      import.meta.env.VITE_KAKAO_MAP_KEY
+    }&autoload=false&libraries=services`;
+
+    script.onload = () => {
+      window.kakao.maps.load(() => {
+        setIsKakaoMapLoaded(true);
+      });
+    };
+
+    document.head.appendChild(script);
+  };
+
+  const loadPostcode = () => {
+    const script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src =
+      "//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js";
+    script.onload = () => {
+      setIsPostcodeLoaded(true);
+    };
+    document.head.appendChild(script);
+  };
+
   useEffect(() => {
-    window.kakao.maps.load(() => {
+    if (!isKakaoMapLoaded) {
+      loadKakaoMaps();
+    }
+    if (!isPostcodeLoaded) {
+      loadPostcode();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isKakaoMapLoaded) {
       const container = document.getElementById("map");
       const beforePos = new window.kakao.maps.LatLng(beforeLat, beforeLon);
       const options = {
@@ -39,10 +79,13 @@ const SearchMap = ({
       }
       setMap(map);
       setMarker(marker);
-    });
-  }, []);
+    }
+  }, [isKakaoMapLoaded]);
 
   const onClickAddr = () => {
+    if (!isKakaoMapLoaded || !isPostcodeLoaded) {
+      return;
+    }
     new window.daum.Postcode({
       oncomplete: function (addrData) {
         const geocoder = new window.kakao.maps.services.Geocoder();


### PR DESCRIPTION
지도 출력 방식을 바꾸고 나서 새로고침 시 출력되지 않는 문제를 해결하였습니다

## 반영 브랜치
hotfix#110-map-bug-fix -> FE_dev

## PR 요약
지도 스크립트 로드 방식을 개선하고 나서, 새로고침 시 지도가 출력되지 않는 문제가 있었는데 이를 해결했습니다.

## PR 설명
index.html에 스크립트를 두고 이를 로드하는 방식으로 했었는데, 이 방법으로 하게 될 경우 새로고침 시 window.map을 인식을 못하는 상황이 발생하였다. 그래서 우선 hotfix를 진행하였다. 이후에 원인에 대한 고찰이 필요하다.