### PR TITLE
Config/#119 테스트 환경 설정

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/dto/ReservationRequest.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/dto/ReservationRequest.java
@@ -1,13 +1,11 @@
 package com.hansalchai.haul.reservation.dto;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 import org.hibernate.validator.constraints.Range;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.hansalchai.haul.reservation.constants.TransportType;
 import com.hansalchai.haul.reservation.entity.Cargo;
 import com.hansalchai.haul.reservation.entity.CargoOption;
 import com.hansalchai.haul.reservation.entity.Destination;
@@ -15,6 +13,7 @@ import com.hansalchai.haul.reservation.entity.Source;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -39,8 +38,8 @@ public class ReservationRequest {
 		private CargoOptionDTO cargoOption;
 
 		@Getter
-		@Setter
 		@ToString
+		@NoArgsConstructor
 		public static class SourceDTO {
 			@NotNull(message = "출발지 이름은 Null 일 수 없다.")
 			private String name;
@@ -60,7 +59,18 @@ public class ReservationRequest {
 			@NotNull(message = "출발지 전화번호는 Null 일 수 없다.")
 			private String tel;
 
-			public Source build(){
+			@Builder
+			public SourceDTO(String name, String address, String detailAddress, double latitude, double longitude,
+				String tel) {
+				this.name = name;
+				this.address = address;
+				this.detailAddress = detailAddress;
+				this.latitude = latitude;
+				this.longitude = longitude;
+				this.tel = tel;
+			}
+
+			public Source build() {
 				return Source.builder()
 					.name(name)
 					.address(address)
@@ -71,9 +81,10 @@ public class ReservationRequest {
 					.build();
 			}
 		}
+
 		@Getter
-		@Setter
 		@ToString
+		@NoArgsConstructor
 		public static class DestinationDTO {
 			@NotNull(message = "도착지 이름은 Null 일 수 없다.")
 			private String name;
@@ -93,6 +104,17 @@ public class ReservationRequest {
 			@NotNull(message = "도착지 전화번호는 Null 일 수 없다.")
 			private String tel;
 
+			@Builder
+			public DestinationDTO(String name, String address, String detailAddress, double latitude, double longitude,
+				String tel) {
+				this.name = name;
+				this.address = address;
+				this.detailAddress = detailAddress;
+				this.latitude = latitude;
+				this.longitude = longitude;
+				this.tel = tel;
+			}
+
 			public Destination build(){
 				return Destination.builder()
 					.name(name)
@@ -104,9 +126,10 @@ public class ReservationRequest {
 					.build();
 			}
 		}
+
 		@Getter
-		@Setter
 		@ToString
+		@NoArgsConstructor
 		public static class CargoDTO {
 			@NotNull(message = "화물 가로는 Null 일 수 없다.")
 			@Range(min = 0, max = 1000, message = "화물 가로는 10m를 넘을 수 없다.")
@@ -124,6 +147,14 @@ public class ReservationRequest {
 			@Range(min = 0, max = 1000000, message = "화물 무게는 1000T를 넘을 수 없다.")
 			private int weight;
 
+			@Builder
+			public CargoDTO(int width, int length, int height, int weight) {
+				this.width = width;
+				this.length = length;
+				this.height = height;
+				this.weight = weight;
+			}
+
 			public Cargo build(){
 				return Cargo.builder()
 					.width(width)
@@ -133,9 +164,10 @@ public class ReservationRequest {
 					.build();
 			}
 		}
+
 		@Getter
-		@Setter
 		@ToString
+		@NoArgsConstructor
 		public static class CargoOptionDTO {
 			@JsonProperty("refrigerated")
 			@NotNull(message = "냉장여부는 Null 일 수 없다.")
@@ -152,6 +184,15 @@ public class ReservationRequest {
 			@JsonProperty("liftRequired")
 			@NotNull(message = "리프트필요여부는 Null 일 수 없다.")
 			private boolean isLiftRequired;
+
+			@Builder
+			public CargoOptionDTO(boolean isRefrigerated, boolean isFrozen, boolean isFurniture,
+				boolean isLiftRequired) {
+				this.isRefrigerated = isRefrigerated;
+				this.isFrozen = isFrozen;
+				this.isFurniture = isFurniture;
+				this.isLiftRequired = isLiftRequired;
+			}
 
 			public CargoOption build(){
 				return CargoOption.builder()

--- a/haul-be/src/main/resources/db/teardown.sql
+++ b/haul-be/src/main/resources/db/teardown.sql
@@ -1,9 +1,3 @@
-SET REFERENTIAL_INTEGRITY FALSE;
-TRUNCATE TABLE users;
-TRUNCATE TABLE car;
-TRUNCATE TABLE reservation;
-SET REFERENTIAL_INTEGRITY TRUE;
-
 INSERT INTO users (name, tel, password, email, photo, role, created_at, updated_at)
 VALUES
     ('John Doe', '1234567890', 'password1', 'john@example.com', 'john.jpg', 'CUSTOMER', NOW(), NOW()),

--- a/haul-be/src/test/java/com/hansalchai/haul/reservation/ReservationTest.java
+++ b/haul-be/src/test/java/com/hansalchai/haul/reservation/ReservationTest.java
@@ -1,17 +1,17 @@
 package com.hansalchai.haul.reservation;
 
-
+import static com.hansalchai.haul.common.auth.jwt.JwtProvider.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hansalchai.haul.common.auth.constants.Role;
+import com.hansalchai.haul.common.auth.dto.AuthenticatedUser;
 import com.hansalchai.haul.common.utils.ReservationNumberGenerator;
-import com.hansalchai.haul.reservation.constants.TransportType;
 import com.hansalchai.haul.reservation.dto.ReservationRequest;
 import com.hansalchai.haul.reservation.dto.ReservationResponse;
 import com.hansalchai.haul.reservation.service.ReservationService;
@@ -53,39 +53,6 @@ public class ReservationTest {
 			.build();
 	}
 
-	private ReservationRequest.CreateReservationDTO makeDummyReservationRequestDTO(){
-		ReservationRequest.CreateReservationDTO.SourceDTO src = new ReservationRequest.CreateReservationDTO.SourceDTO();
-		src.setName("광주");
-		src.setAddress("광주광역시 서구 상무민주로 119 나나빌딩");
-		src.setTel("01012345678");
-		src.setDetailAddress("구이덕");
-		src.setLatitude(37.4851943071576);
-		src.setLongitude(126.717952447459);
-
-		ReservationRequest.CreateReservationDTO.DestinationDTO dst = new ReservationRequest.CreateReservationDTO.DestinationDTO();
-		dst.setName("부산");
-		dst.setAddress("부산광역시 연제구 거제대로178번길 51-2");
-		dst.setDetailAddress("종갓집 양곱창");
-		dst.setLatitude(37.4482284563797);
-		dst.setLongitude(126.649653068211);
-		dst.setTel("01012345678");
-
-		ReservationRequest.CreateReservationDTO.CargoDTO cargo = new ReservationRequest.CreateReservationDTO.CargoDTO();
-		cargo.setWidth(1);
-		cargo.setLength(1);
-		cargo.setHeight(1);
-		cargo.setWeight(1);
-
-		ReservationRequest.CreateReservationDTO.CargoOptionDTO cargoOption = new ReservationRequest.CreateReservationDTO.CargoOptionDTO();
-		cargoOption.setRefrigerated(true);
-		cargoOption.setFurniture(false);
-		cargoOption.setLiftRequired(true);
-		cargoOption.setFrozen(false);
-
-		return new ReservationRequest.CreateReservationDTO(
-			"일반 용달", LocalDate.parse("2024-02-14"), LocalTime.parse("14:30:00"),src, dst, cargo, cargoOption);
-	}
-
 	@Test
 	@DisplayName("예약 중복 테스트")
 	void ReservationDuplicationTest() throws Exception{
@@ -107,7 +74,6 @@ public class ReservationTest {
 		Assertions.assertEquals("포터2", actual.getCar().getModel());
 	}
 
-	//TODO 토큰이 없어서 실패함
 	@Test
 	@DisplayName("고객은 화물차를 예약할 수 있습니다.")
 	void ReservationMVCTest() throws Exception {
@@ -119,6 +85,7 @@ public class ReservationTest {
 		// when
 		ResultActions resultActions = mvc.perform(
 			post("/api/v1/reservations")
+				.requestAttr(AUTHENTICATE_USER, new AuthenticatedUser(1L, Role.CUSTOMER))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonContent)
 		);
@@ -137,5 +104,50 @@ public class ReservationTest {
 		for(int i = 0;i<30;i++){
 			logger.info(ReservationNumberGenerator.generateUniqueId());
 		}
+	}
+
+	private ReservationRequest.CreateReservationDTO makeDummyReservationRequestDTO() {
+
+		ReservationRequest.CreateReservationDTO.SourceDTO src = ReservationRequest.CreateReservationDTO.SourceDTO.builder()
+			.name("나나빌딩")
+			.address("광주광역시 서구 상무민주로 119 나나빌딩")
+			.tel("01012345678")
+			.detailAddress("3층")
+			.latitude(37.4851943071576)
+			.longitude(126.717952447459)
+			.build();
+
+		ReservationRequest.CreateReservationDTO.DestinationDTO dst = ReservationRequest.CreateReservationDTO.DestinationDTO.builder()
+			.name("종갓집 양곱창")
+			.address("부산광역시 연제구 거제대로178번길 51-2")
+			.tel("01012345678")
+			.detailAddress("1층")
+			.latitude(37.4482284563797)
+			.longitude(126.649653068211)
+			.build();
+
+		ReservationRequest.CreateReservationDTO.CargoDTO cargo = ReservationRequest.CreateReservationDTO.CargoDTO.builder()
+			.width(1)
+			.length(1)
+			.height(1)
+			.weight(1)
+			.build();
+
+		ReservationRequest.CreateReservationDTO.CargoOptionDTO cargoOption = ReservationRequest.CreateReservationDTO.CargoOptionDTO.builder()
+			.isRefrigerated(true)
+			.isFurniture(false)
+			.isLiftRequired(false)
+			.isFrozen(false)
+			.build();
+
+		return new ReservationRequest.CreateReservationDTO(
+			"일반 용달",
+			LocalDate.parse("2024-02-14"),
+			LocalTime.parse("14:30:00"),
+			src,
+			dst,
+			cargo,
+			cargoOption
+		);
 	}
 }


### PR DESCRIPTION
## 반영 브랜치
ex) config/#119-test-env -> BE_dev

## PR 요약
- 테스트 환경을 개발 환경과 동일하게 mysql로 세팅

## PR 설명
- **haul-be/src/test/resources/application.yml 수정**
haul-test 데이터베이스를 사용하도록 설정했다.

- **SQL 스크립트 수정**
기존 코드는 h2의 제약조건을 무효화한다. 그러나 테스트 환경을 mysql로 변경하면서 해당 코드가 필요없어졌으므로 제거했다.

- **테스트 코드 동작 확인 및 테스트 코드 수정**
  1. 클래스를 역직렬화할 때 기본 생성자가 없어서 InvalidDefinitionException 오류가 발생했다. 따라서 기본 생성자를 추가하는 @NoArgsConstructor를 dto에 추가했다.
  2. 토큰이 없어 MockMvc를 활용한 테스트에서 NPE가 발생했다. 따라서 AuthenticatedUser 객체를 request의 속성으로 추가했다.

- **테스트 코드에 빌더패턴 적용**
Setter는 전역에서 객체의 필드를 수정할 수 있으므로 빌더 패턴을 사용해 객체를 생성하도록 변경했다.

## ETC
Close #119 
