### PR TITLE
Feat/#126 오더 운송 상태 변경 api 구현

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
@@ -15,15 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.hansalchai.haul.common.auth.dto.AuthenticatedUser;
 import com.hansalchai.haul.common.utils.ApiResponse;
-import com.hansalchai.haul.common.utils.SuccessCode;
 import com.hansalchai.haul.order.dto.ApproveRequestDto;
-import com.hansalchai.haul.order.dto.OrderResponse;
 import com.hansalchai.haul.order.dto.OrderResponse.OrderDTO;
 import com.hansalchai.haul.order.dto.OrderResponse.OrderDetailDTO;
-import com.hansalchai.haul.order.dto.ApproveRequestDto;
 import com.hansalchai.haul.order.dto.OrderSearchResponse;
+import com.hansalchai.haul.order.dto.TransportStatusChange;
 import com.hansalchai.haul.order.service.OrderService;
-import com.hansalchai.haul.reservation.dto.ReservationResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -68,5 +65,12 @@ public class OrderController {
 		AuthenticatedUser auth = (AuthenticatedUser)request.getAttribute(AUTHENTICATE_USER);
 		OrderDetailDTO response = orderService.getOrderDetail(id, auth.getUserId());
 		return ResponseEntity.ok(success(GET_SUCCESS, response));
+	}
+
+	@PatchMapping("/status")
+	public ResponseEntity<ApiResponse<TransportStatusChange.ResponseDto>> changeTransportStatus(
+			@Valid @RequestBody TransportStatusChange.RequestDto requestDto) {
+		TransportStatusChange.ResponseDto responseDto = orderService.changeTransportStatus(requestDto);
+		return ResponseEntity.ok(success(GET_SUCCESS, responseDto));
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/order/dto/ApproveRequestDto.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/dto/ApproveRequestDto.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 public class ApproveRequestDto {
 
 	@NotNull(message = "예약 id는 null일 수 없다.")
-	private Long reservationId;
+	private Long id;
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/order/dto/OrderSearchResponse.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/dto/OrderSearchResponse.java
@@ -29,7 +29,7 @@ public class OrderSearchResponse {
 	@NoArgsConstructor
 	public static class OrderSearchResponseDto {
 
-		private Long orderId;
+		private Long id;
 		private String srcSimpleAddress;
 		private String dstSimpleAddress;
 		private String transportDatetime;
@@ -41,7 +41,7 @@ public class OrderSearchResponse {
 			Destination destination = reservation.getDestination();
 			Transport transport = reservation.getTransport();
 
-			orderId = reservation.getReservationId();
+			id = reservation.getReservationId();
 			srcSimpleAddress = toSimpleAddress(source.getAddress());
 			dstSimpleAddress = toSimpleAddress(destination.getAddress());
 			transportDatetime = dateTimeToString(reservation.getDate(), reservation.getTime());

--- a/haul-be/src/main/java/com/hansalchai/haul/order/dto/TransportStatusChange.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/dto/TransportStatusChange.java
@@ -17,9 +17,6 @@ public class TransportStatusChange {
 
 		@NotNull(message = "오더 id는 null일 수 없다.")
 		private Long id; //오더 id
-
-		@NotNull(message = "운송 상태는 null일 수 없다.")
-		private String transportStatus;
 	}
 
 	// 운송 상태 변경 응답 dto

--- a/haul-be/src/main/java/com/hansalchai/haul/order/dto/TransportStatusChange.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/dto/TransportStatusChange.java
@@ -1,0 +1,35 @@
+package com.hansalchai.haul.order.dto;
+
+import com.hansalchai.haul.reservation.entity.Reservation;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TransportStatusChange {
+
+	// 운송 상태 변경 요청 dto
+	@Getter
+	@NoArgsConstructor
+	public static class RequestDto {
+
+		@NotNull(message = "오더 id는 null일 수 없다.")
+		private Long id; //오더 id
+
+		@NotNull(message = "운송 상태는 null일 수 없다.")
+		private String transportStatus;
+	}
+
+	// 운송 상태 변경 응답 dto
+	@Getter
+	public static class ResponseDto {
+
+		private Long id; //오더 id
+
+		public ResponseDto(Reservation reservation) {
+			this.id = reservation.getReservationId();
+		}
+	}
+}

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -121,11 +121,10 @@ public class OrderService {
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 오더 id입니다."));
 
 		// 2. 다음 단계의 운송 상태 가져오기(운송 전 -> 운송 중, 운송 중 -> 운송 완료)
-		String currentStatus = requestDto.getTransportStatus();
-		TransportStatus nextStatus = TransportStatus.getNextStatus(currentStatus);
+		Transport transport = reservation.getTransport();
+		TransportStatus nextStatus = TransportStatus.getNextStatus(transport.getTransportStatus());
 
 		// 3. 운송 상태 업데이트
-		Transport transport = reservation.getTransport();
 		transport.updateTransportStatus(nextStatus);
 
 		return new TransportStatusChange.ResponseDto(reservation);

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -77,7 +77,7 @@ public class OrderService {
 	public void approve(Long driverId, ApproveRequestDto approveRequestDto) {
 
 		// 1. 예약 정보 가져오기
-		Reservation reservation = reservationRepository.findById(approveRequestDto.getReservationId())
+		Reservation reservation = reservationRepository.findById(approveRequestDto.getId())
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약번호입니다."));
 
 		// 2. 기사 정보 가져오기

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/constants/TransportStatus.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/constants/TransportStatus.java
@@ -1,5 +1,6 @@
 package com.hansalchai.haul.reservation.constants;
 
+import java.util.Arrays;
 
 public enum TransportStatus {
 	NOT_RESERVATED("예약 전"),
@@ -9,6 +10,7 @@ public enum TransportStatus {
 	DONE("운송 완료");
 
 	private final String code;
+
 	TransportStatus(String code) {
 		this.code = code;
 	}
@@ -19,5 +21,24 @@ public enum TransportStatus {
 
 	public static String getCode(TransportStatus status) {
 		return status.getCode();
+	}
+
+	public static TransportStatus getNextStatus(String currentStatus) {
+
+		// 문자열 형태의 운송 상태를 enum 상수로 변환
+		TransportStatus transportStatus = getTransportStatus(currentStatus);
+
+		// 다음 운송 상태를 반환
+		if (transportStatus == NOT_STARTED) {
+			return IN_PROGRESS;
+		}
+		return DONE;
+	}
+
+	private static TransportStatus getTransportStatus(String input) {
+		return Arrays.stream(TransportStatus.values())
+			.filter(transportStatus -> transportStatus.code.equals(input))
+			.findAny()
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 운송 상태입니다."));
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/constants/TransportStatus.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/constants/TransportStatus.java
@@ -1,7 +1,5 @@
 package com.hansalchai.haul.reservation.constants;
 
-import java.util.Arrays;
-
 public enum TransportStatus {
 	NOT_RESERVATED("예약 전"),
 	PENDING("매칭 중"),
@@ -23,22 +21,17 @@ public enum TransportStatus {
 		return status.getCode();
 	}
 
-	public static TransportStatus getNextStatus(String currentStatus) {
+	// 다음 단계의 운송 상태를 반환
+	public static TransportStatus getNextStatus(TransportStatus currentStatus) {
 
-		// 문자열 형태의 운송 상태를 enum 상수로 변환
-		TransportStatus transportStatus = getTransportStatus(currentStatus);
-
-		// 다음 운송 상태를 반환
-		if (transportStatus == NOT_STARTED) {
+		if (currentStatus == NOT_STARTED) {
 			return IN_PROGRESS;
 		}
-		return DONE;
-	}
 
-	private static TransportStatus getTransportStatus(String input) {
-		return Arrays.stream(TransportStatus.values())
-			.filter(transportStatus -> transportStatus.code.equals(input))
-			.findAny()
-			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 운송 상태입니다."));
+		if (currentStatus == IN_PROGRESS) {
+			return DONE;
+		}
+
+		return currentStatus;
 	}
 }

--- a/haul-be/src/test/java/com/hansalchai/haul/order/dto/TransportStatusChangeTest.java
+++ b/haul-be/src/test/java/com/hansalchai/haul/order/dto/TransportStatusChangeTest.java
@@ -1,0 +1,32 @@
+package com.hansalchai.haul.order.dto;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hansalchai.haul.reservation.entity.Reservation;
+
+@ExtendWith(MockitoExtension.class)
+class TransportStatusChangeTest {
+
+	@Mock Reservation mockReservation;
+
+	@Test
+	@DisplayName("TransportStatusChange.ResponseDto 생성자를 통한 객체 생성 테스트")
+	void ResponseDtoTest() {
+
+		//given
+		when(mockReservation.getReservationId()).thenReturn(1L);
+
+		//when
+		TransportStatusChange.ResponseDto responseDto = new TransportStatusChange.ResponseDto(mockReservation);
+
+		//then
+		assertThat(responseDto.getId()).isEqualTo(1L);
+	}
+}


### PR DESCRIPTION
## 반영 브랜치
ex) feat/#126-change-transport-status-api -> BE_dev

## PR 요약
- 운송 상태 변경 api 구현

## PR 설명
**1. TransportStatus.getNextStatus()**
전달 받은 운송 상태의 **다음 단계 운송 상태 값을 반환**합니다.
'운송 전'이면 '운송 중' 상수를, '운송 중'이면 '운송 완료' 상수를 반환합니다.

**2. TransportStatusChange.ResponseDto** 
상세 페이지를 재조회하여 변경된 운송 상태 값을 확인할 수 있도록 **오더 id 값을 반환**했습니다.

**(3. TransportStatusChange.ResponseDto 생성자를 통한 객체 생성 테스트)**
내부 클래스의 생성자가 잘 동작하는지 확인하는 테스트 코드를 **mock**을 활용해 작성했습니다.

**4. 오더 id 변수명 통일**
기존 코드엔 오더 id 변수명이 reservationId, orderId, id로 혼재했습니다. 따라서 `id`로 변수명을 통일하였습니다.

## Discuss
**1. 운송 상태 변경 방법**
운송 상태를 변경하는 방법은 2가지로 생각해봤습니다.
1. db에 저장된 transportStatus를 조회해서 다음 운송 상태로 바꾸기
2. 클라이언트에서 현재 운송 상태('운송 전')을 보내주면 다음 운송 상태로 바꾸기   

현재 코드는 둘 중 db 조회를 하지 않는, 방법 2를 채택했습니다. 
그런데 클라이언트에서 현재 운송 상태를 보내주는 과정에서 transportStatus 데이터가 조작되면 의도하지 않은 결과가 저장, 응답됩니다. 그럼 1번 방법으로 운송 상태를 바꾸는 게 좋을까요?

**2. 요청 보낸 사람 검증하기?**
현재 코드는 토큰의 userId와 예약의 owner.user.userId를 비교하지 않습니다.
이 경우 예약 id만 알면 다른 사람이 예약 상태를 변경할 수 있게 됩니다. 
이 부분 처리해야겠죠

## ETC
- 응답 dto에 `@Getter`가 있어야할지 고민했는데 테스트에서 값을 검증할 때 필요했습니다.
