### PR TITLE
Feat/#137 code refactor sean2337

### DIFF
--- a/haul-driver-fe/src/components/NavigationBar/NavigationBar.jsx
+++ b/haul-driver-fe/src/components/NavigationBar/NavigationBar.jsx
@@ -68,7 +68,7 @@ const NavigationBar = ({ selected = "create" }) => {
     navigator(UrlMap.scheduleCheckPageUrl);
   };
   const clickCreate = () => {
-    navigator(UrlMap.scheduleCreateDetailPageUrl);
+    navigator(UrlMap.scheduleCreatePageUrl);
   };
   const clickMore = () => {
     navigator(UrlMap.morePageUrl);

--- a/haul-driver-fe/src/data/GlobalVariable.js
+++ b/haul-driver-fe/src/data/GlobalVariable.js
@@ -3,7 +3,7 @@ export const MaxDeviceWidth = "400px";
 export const UrlMap = {
   loginPageUrl: "/login",
   completePageUrl: "/schedule-create/complete",
-  scheduleCreateDetailPageUrl: "/schedule-create",
+  scheduleCreatePageUrl: "/schedule-create",
   scheduleCheckPageUrl: "/schedule-check",
   morePageUrl: "/more"
 };

--- a/haul-driver-fe/src/views/Login/Login.jsx
+++ b/haul-driver-fe/src/views/Login/Login.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import MobileLayout from "../../components/MobileLayout/MobileLayout.jsx";
 import Typography from "../../components/Typhography/Typhography.jsx";
 import TypographySpan from "../../components/Typhography/TyphographySpan.jsx";
@@ -7,16 +7,10 @@ import Margin from "../../components/Margin/Margin.jsx";
 import Input from "../../components/Input/Input.jsx";
 import BottomButton from "../../components/Button/BottomButton.jsx";
 import FixedCenterBox from "../../components/FixedBox/FixedCenterBox.jsx";
-import { ErrorMessageMap, UrlMap } from "../../data/GlobalVariable.js";
-import { isPhoneNumber, deleteDash, isValueArr } from "../../utils/helper.js";
-import ToastMaker from "../../components/Toast/ToastMaker.jsx";
+import { checkLoginAbled, loginBtnFun } from "./index.jsx";
+import { isLoginFun } from "../../utils/localStorage.js";
 import { useNavigate } from "react-router-dom";
-import { loginFun } from "../../repository/userRepository.jsx";
-import {
-  setAccessToken,
-  setRefreshToken,
-  setUserName
-} from "../../utils/localStorage.js";
+import { UrlMap } from "../../data/GlobalVariable.js";
 
 const Login = () => {
   const navigate = useNavigate();
@@ -24,38 +18,10 @@ const Login = () => {
   const password = useRef("");
   const [isButtonDisabled, setButtonDisabled] = useState(true);
 
-  function checkLoginAbled() {
-    const checkIsButtonDisabled = !isValueArr([
-      tel.current.trim(),
-      password.current.trim()
-    ]);
-    if (checkIsButtonDisabled !== isButtonDisabled) {
-      setButtonDisabled(checkIsButtonDisabled);
-    }
-  }
-
-  //로그인 버튼 클릭 시 실행 함수
-  async function loginBtnFun() {
-    tel.current = deleteDash(tel.current);
-    //전화번호 형식 예외처리
-    if (!isPhoneNumber(tel.current)) {
-      ToastMaker({ type: "error", children: ErrorMessageMap.InvalidTelformat });
-      return;
-    }
-    const { success, data, message } = await loginFun({
-      tel: tel.current,
-      password: password.current
-    });
-    if (success) {
-      setAccessToken(data.data.jwt.accessToken);
-      setRefreshToken(data.data.jwt.refreshToken);
-      setUserName(data.data.name);
-      navigate(UrlMap.scheduleCreateDetailPageUrl);
-    } else {
-      //FIXME: 로그인 실패 예외처리
-      ToastMaker({ type: "error", children: message });
-    }
-  }
+  useEffect(() => {
+    const isLogin = isLoginFun();
+    if (isLogin) navigate(UrlMap.scheduleCreatePageUrl);
+  });
 
   return (
     <MobileLayout>
@@ -80,7 +46,12 @@ const Login = () => {
           placeholder="Phone Number "
           onChange={({ target: { value } }) => {
             tel.current = value;
-            checkLoginAbled();
+            checkLoginAbled({
+              tel: tel.current,
+              password: password.current,
+              isButtonDisabled: isButtonDisabled,
+              setButtonDisabled: setButtonDisabled
+            });
           }}
         />
         <Margin height="20px" />
@@ -90,7 +61,12 @@ const Login = () => {
           placeholder="Password "
           onChange={({ target: { value } }) => {
             password.current = value;
-            checkLoginAbled();
+            checkLoginAbled({
+              tel: tel.current,
+              password: password.current,
+              isButtonDisabled: isButtonDisabled,
+              setButtonDisabled: setButtonDisabled
+            });
           }}
         />
       </form>
@@ -100,7 +76,7 @@ const Login = () => {
           role="main"
           disabled={isButtonDisabled}
           onClick={() => {
-            loginBtnFun();
+            loginBtnFun({ tel: tel.current, password: password.current });
           }}
         >
           로그인하기

--- a/haul-driver-fe/src/views/Login/index.jsx
+++ b/haul-driver-fe/src/views/Login/index.jsx
@@ -1,0 +1,44 @@
+import { ErrorMessageMap, UrlMap } from "../../data/GlobalVariable.js";
+import { isPhoneNumber, deleteDash, isValueArr } from "../../utils/helper.js";
+import ToastMaker from "../../components/Toast/ToastMaker.jsx";
+import { loginFun } from "../../repository/userRepository.jsx";
+import {
+  setAccessToken,
+  setRefreshToken,
+  setUserName
+} from "../../utils/localStorage.js";
+
+export function checkLoginAbled({
+  tel,
+  password,
+  isButtonDisabled,
+  setButtonDisabled
+}) {
+  const checkIsButtonDisabled = !isValueArr([tel.trim(), password.trim()]);
+  if (checkIsButtonDisabled !== isButtonDisabled) {
+    setButtonDisabled(checkIsButtonDisabled);
+  }
+}
+
+//로그인 버튼 클릭 시 실행 함수
+export async function loginBtnFun({ tel, password }) {
+  tel = deleteDash(tel);
+  //전화번호 형식 예외처리
+  if (!isPhoneNumber(tel)) {
+    ToastMaker({ type: "error", children: ErrorMessageMap.InvalidTelformat });
+    return;
+  }
+  const { success, data, message } = await loginFun({
+    tel: tel,
+    password: password
+  });
+  if (success) {
+    setAccessToken(data.data.jwt.accessToken);
+    setRefreshToken(data.data.jwt.refreshToken);
+    setUserName(data.data.name);
+    window.location.href = UrlMap.scheduleCreatePageUrl;
+  } else {
+    //FIXME: 로그인 실패 예외처리
+    ToastMaker({ type: "error", children: message });
+  }
+}

--- a/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckDetail/ScheduleCheckDetail.jsx
+++ b/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckDetail/ScheduleCheckDetail.jsx
@@ -1,3 +1,5 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
 import MobileLayout from "../../../components/MobileLayout/MobileLayout";
 import Header from "../../../components/Header/Header.jsx";
 import TypographySpan from "../../../components/Typhography/TyphographySpan.jsx";
@@ -8,12 +10,9 @@ import DetailInfo from "../../../components/DetailInfo/DetailInfo.jsx";
 import HaulInfoBox from "../../../components/HaulInfoBox/HaulInfoBox.jsx";
 import Carousel from "../../../components/Carousel/Carousel.jsx";
 import DriverStatusButton from "./components/DriverStatusButton.jsx";
-import ToastMaker from "../../../components/Toast/ToastMaker.jsx";
 import Loading from "../../Loading/Loading.jsx";
-import { useParams, useNavigate } from "react-router-dom";
-import { checkOrderDetail } from "../../../repository/checkRepository.jsx";
-import { useState, useEffect } from "react";
 import { getUserName } from "../../../utils/localStorage.js";
+import { showDetailFun } from "./index.jsx";
 
 const ScheduleCheckDetail = () => {
   const { orderId } = useParams();
@@ -22,21 +21,12 @@ const ScheduleCheckDetail = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    showDetailFun();
-  }, []);
-
-  async function showDetailFun() {
-    const { success, data, message } = await checkOrderDetail({
-      orderId: orderId
+    showDetailFun({
+      orderId: orderId,
+      setOrderData: setOrderData,
+      navigate: navigate
     });
-    if (success) {
-      setOrderData(data.data);
-    } else {
-      //FIXME: 예외처리 생성 시 적용
-      ToastMaker({ type: "error", children: message });
-      navigate(-1);
-    }
-  }
+  }, []);
 
   if (!orderData) {
     return <Loading />;
@@ -78,7 +68,6 @@ const ScheduleCheckDetail = () => {
         length={orderData.cargo.length}
         height={orderData.cargo.height}
       />
-
       <Margin height="24px" />
       <DetailInfo
         srcCoordinate={{
@@ -97,7 +86,6 @@ const ScheduleCheckDetail = () => {
         time={orderData.requiredTime}
       />
       <Margin height="30px" />
-
       <DriverStatusButton
         orderId={orderId}
         status={orderData.transportStatus}

--- a/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckDetail/components/DriverStatusButton.jsx
+++ b/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckDetail/components/DriverStatusButton.jsx
@@ -1,48 +1,33 @@
 import FixedCenterBox from "../../../../components/FixedBox/FixedCenterBox";
 import BottomButton from "../../../../components/Button/BottomButton";
 import { useState } from "react";
-import ToastMaker from "../../../../components/Toast/ToastMaker";
-import { orderStatusChage } from "../../../../repository/checkRepository";
+import { driveStartFun, driveEndFun } from "..";
 
 const DriverStatusButton = ({ orderId, status }) => {
   const [driverStatus, setDriverStatus] = useState(status);
 
-  async function driveStartFun(orderId) {
-    const { success, data, message } = await orderStatusChage({
-      orderId: orderId
-    });
-    if (success) {
-      setDriverStatus("운송 중");
-      ToastMaker({ type: "success", children: "안전 운전 되세요." });
-    } else {
-      //FIXME: 예외처리 생성 시 적용
-      ToastMaker({ type: "error", children: message });
-    }
-  }
-
-  async function driveEndFun(orderId) {
-    //도착 로직
-    const { success, data, message } = await orderStatusChage({
-      orderId: orderId
-    });
-    if (success) {
-      setDriverStatus("운송 완료");
-      ToastMaker({ type: "success", children: "운행이 종료되었습니다." });
-    } else {
-      //FIXME: 예외처리 생성 시 적용
-      ToastMaker({ type: "error", children: message });
-    }
-  }
-
   return (
     <FixedCenterBox bottom="30px">
       {driverStatus === "운송 전" && (
-        <BottomButton role="main" onClick={() => driveStartFun(orderId)}>
+        <BottomButton
+          role="main"
+          onClick={() =>
+            driveStartFun({
+              orderId: orderId,
+              setDriverStatus: setDriverStatus
+            })
+          }
+        >
           운송 출발
         </BottomButton>
       )}
       {driverStatus === "운송 중" && (
-        <BottomButton role="sub" onClick={() => driveEndFun(orderId)}>
+        <BottomButton
+          role="sub"
+          onClick={() =>
+            driveEndFun({ orderId: orderId, setDriverStatus: setDriverStatus })
+          }
+        >
           운송 도착
         </BottomButton>
       )}

--- a/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckDetail/index.jsx
+++ b/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckDetail/index.jsx
@@ -1,0 +1,45 @@
+import ToastMaker from "../../../components/Toast/ToastMaker.jsx";
+import {
+  checkOrderDetail,
+  orderStatusChage
+} from "../../../repository/checkRepository.jsx";
+
+export async function showDetailFun({ orderId, setOrderData, navigate }) {
+  const { success, data, message } = await checkOrderDetail({
+    orderId: orderId
+  });
+  if (success) {
+    setOrderData(data.data);
+  } else {
+    //FIXME: 예외처리 생성 시 적용
+    ToastMaker({ type: "error", children: message });
+    navigate(-1);
+  }
+}
+
+export async function driveStartFun({ orderId, setDriverStatus }) {
+  const { success, data, message } = await orderStatusChage({
+    orderId: orderId
+  });
+  if (success) {
+    setDriverStatus("운송 중");
+    ToastMaker({ type: "success", children: "안전 운전 되세요." });
+  } else {
+    //FIXME: 예외처리 생성 시 적용
+    ToastMaker({ type: "error", children: message });
+  }
+}
+
+export async function driveEndFun({ orderId, setDriverStatus }) {
+  //도착 로직
+  const { success, data, message } = await orderStatusChage({
+    orderId: orderId
+  });
+  if (success) {
+    setDriverStatus("운송 완료");
+    ToastMaker({ type: "success", children: "운행이 종료되었습니다." });
+  } else {
+    //FIXME: 예외처리 생성 시 적용
+    ToastMaker({ type: "error", children: message });
+  }
+}

--- a/haul-driver-fe/src/views/ScheduleCreate/Complete/Complete.jsx
+++ b/haul-driver-fe/src/views/ScheduleCreate/Complete/Complete.jsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import MobileLayout from "../../../components/MobileLayout/MobileLayout.jsx";
 import Typography from "../../../components/Typhography/Typhography.jsx";
 import TypographySpan from "../../../components/Typhography/TyphographySpan.jsx";
@@ -8,7 +9,6 @@ import BottomButton from "../../../components/Button/BottomButton.jsx";
 import FixedCenterBox from "../../../components/FixedBox/FixedCenterBox.jsx";
 import Flex from "../../../components/Flex/Flex.jsx";
 import { UrlMap } from "../../../data/GlobalVariable.js";
-import { useNavigate } from "react-router-dom";
 
 const Complete = () => {
   const navigation = useNavigate();
@@ -35,18 +35,14 @@ const Complete = () => {
       <FixedCenterBox bottom="30px">
         <BottomButton
           role="main"
-          onClick={() => {
-            goHome();
-          }}
+          onClick={goHome}
         >
           다른 일정 잡기
         </BottomButton>
         <Margin height="10px" />
         <BottomButton
           role="sub"
-          onClick={() => {
-            goReservationList();
-          }}
+          onClick={goReservationList}
         >
           일정 확인 하기
         </BottomButton>

--- a/haul-driver-fe/src/views/ScheduleCreate/Complete/Complete.jsx
+++ b/haul-driver-fe/src/views/ScheduleCreate/Complete/Complete.jsx
@@ -13,7 +13,7 @@ import { useNavigate } from "react-router-dom";
 const Complete = () => {
   const navigation = useNavigate();
   function goHome() {
-    navigation(UrlMap.scheduleCreateDetailPageUrl);
+    navigation(UrlMap.scheduleCreatePageUrl);
   }
   function goReservationList() {
     navigation(UrlMap.scheduleCheckPageUrl);

--- a/haul-driver-fe/src/views/ScheduleCreate/ScheduleCreateDetail/ScheduleCreateDetail.jsx
+++ b/haul-driver-fe/src/views/ScheduleCreate/ScheduleCreateDetail/ScheduleCreateDetail.jsx
@@ -10,14 +10,9 @@ import DetailInfo from "../../../components/DetailInfo/DetailInfo.jsx";
 import HaulInfoBox from "../../../components/HaulInfoBox/HaulInfoBox.jsx";
 import BottomButton from "../../../components/Button/BottomButton.jsx";
 import Carousel from "../../../components/Carousel/Carousel.jsx";
-import ToastMaker from "../../../components/Toast/ToastMaker.jsx";
-import { UrlMap } from "../../../data/GlobalVariable.js";
 import Loading from "../../Loading/Loading.jsx";
-import {
-  orderApprove,
-  orderDetail
-} from "../../../repository/createRepository.jsx";
 import { getUserName } from "../../../utils/localStorage.js";
+import { showDetailFun, createScheduleBtnFun } from "./index.jsx";
 
 const ScheduleCreateDetail = () => {
   const { orderId } = useParams();
@@ -27,31 +22,12 @@ const ScheduleCreateDetail = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    showDetailFun();
+    showDetailFun({
+      orderId: orderId,
+      setOrderData: setOrderData,
+      navigate: navigate
+    });
   }, []);
-
-  async function showDetailFun() {
-    const { success, data, message } = await orderDetail({ orderId: orderId });
-    if (success) {
-      setOrderData(data.data);
-    } else {
-      //FIXME: 예외처리 생성 시 적용
-      ToastMaker({ type: "error", children: message });
-      navigate(-1);
-    }
-  }
-
-  async function createScheduleBtnFun() {
-    setLoadingStatus(true);
-    const { success, data, message } = await orderApprove({ orderId: orderId });
-    if (success) {
-      navigate(UrlMap.completePageUrl);
-    } else {
-      //FIXME: 예외처리 생성 시 적용
-      ToastMaker({ type: "error", children: message });
-      setLoadingStatus(false);
-    }
-  }
 
   if (!orderData || loadingStatus) {
     return <Loading />;
@@ -112,7 +88,16 @@ const ScheduleCreateDetail = () => {
         time={orderData.requiredTime}
       />
       <Margin height="30px" />
-      <BottomButton role="main" onClick={createScheduleBtnFun}>
+      <BottomButton
+        role="main"
+        onClick={() => {
+          createScheduleBtnFun({
+            orderId: orderId,
+            setLoadingStatus: setLoadingStatus,
+            navigate: navigate
+          });
+        }}
+      >
         일정 잡기
       </BottomButton>
       <Margin height="30px" />

--- a/haul-driver-fe/src/views/ScheduleCreate/ScheduleCreateDetail/index.jsx
+++ b/haul-driver-fe/src/views/ScheduleCreate/ScheduleCreateDetail/index.jsx
@@ -1,0 +1,32 @@
+import ToastMaker from "../../../components/Toast/ToastMaker.jsx";
+import { UrlMap } from "../../../data/GlobalVariable.js";
+import {
+  orderApprove,
+  orderDetail
+} from "../../../repository/createRepository.jsx";
+
+export async function showDetailFun({ orderId, setOrderData, navigate }) {
+  const { success, data, message } = await orderDetail({ orderId: orderId });
+  if (success) {
+    setOrderData(data.data);
+  } else {
+    //FIXME: 예외처리 생성 시 적용
+    navigate(UrlMap.scheduleCreatePageUrl);
+  }
+}
+
+export async function createScheduleBtnFun({
+  orderId,
+  setLoadingStatus,
+  navigate
+}) {
+  setLoadingStatus(true);
+  const { success, message } = await orderApprove({ orderId: orderId });
+  if (success) {
+    navigate(UrlMap.completePageUrl);
+  } else {
+    //FIXME: 예외처리 생성 시 적용
+    ToastMaker({ type: "error", children: message });
+    setLoadingStatus(false);
+  }
+}


### PR DESCRIPTION
## 반영 브랜치
feat/#137-code-refactor-sean2337 -> FE_Driver_dev

## PR 요약
- 로그인 페이지 코드 분리 및 리팩토링
- 나의 운송 상세 보기 페이지 분리 및 리팩토링
- 일정 잡기 상세 보기 페이지 분리 및 리팩토링
- 일정 잡기 완료 페이지 분리 및 리팩토링

## PR 설명
- 로그인 페이지 코드 분리 및 리팩토링
로그인 페이지에 사용되는 메인로직은 index.jsx에 배치 시킴으러서, 원래 파일은 페이지의 템플릿 코드만 가져가기 위해 분리시켰습니다. 

- 나의 운송 상세 보기 페이지 분리 및 리팩토링
나의 운송 상세 보기 페이지도 마찬가지로 페이지에서 사용되는 메인로직은 index.jsx에 배치 시킴으러서, 원래 파일은 페이지의 템플릿 코드만 가져가기 위해 분리시켰습니다. 

- 일정 잡기 상세 보기 페이지 분리 및 리팩토링
일정 잡기 상세 보기 페이지도 마찬가지로 페이지에서 사용되는 메인로직은 index.jsx에 배치 시킴으러서, 원래 파일은 페이지의 템플릿 코드만 가져가기 위해 분리시켰습니다. 

- 일정 잡기 완료 리팩토링
일정 잡기의 경우 메인로직이 크지 않아, 따로 분리시키지는 않고 코드 간결화 작업만 진행하였다. 
