### PR TITLE
Feat/#85 오더 관련 예외처리

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/handler/GlobalExceptionHandler.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.hansalchai.haul.common.exceptions.BadRequestException;
 import com.hansalchai.haul.common.exceptions.ConflictException;
 import com.hansalchai.haul.common.exceptions.GeneralException;
 import com.hansalchai.haul.common.exceptions.NotFoundException;
@@ -37,6 +38,12 @@ public class GlobalExceptionHandler {
 		String message = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
 		logInfo(request, HttpStatus.BAD_REQUEST, message);
 		return ApiResponse.error(ErrorCode.MethodArgumentNotValidException);
+	}
+
+	@ExceptionHandler(BadRequestException.class)
+	protected ApiResponse handleBadRequestException(BadRequestException exception, HttpServletRequest request) {
+		logInfo(request, exception.getCode().getStatus(), exception.getCode().getMessage());
+		return ApiResponse.error(exception.getCode());
 	}
 
 	//401 Unauthorized

--- a/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
@@ -8,10 +8,6 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-	/* 400 BAD REQUEST */
-	// general
-	NO_ID(BAD_REQUEST, "40001", "존재하지 않는 id 입니다"),
-	MethodArgumentNotValidException(BAD_REQUEST,"20002002","MethodArgumentNotValidException"),
 
 	//공통
 	PAGE_NOT_FOUND(NOT_FOUND, "1003", "요청한 페이지를 찾을 수 없습니다."),
@@ -31,7 +27,6 @@ public enum ErrorCode {
 	INCORRECT_PASSWORD(UNAUTHORIZED, "2010", "비밀번호가 일치하지 않습니다."),
 
 	// 오더
-	// - 전체 오더 리스트 탐색
 	UNSUPPORTED_QUERY_VALUE(BAD_REQUEST, "5001", "지원하지 않는 쿼리스트링 값입니다."),
 	OWNER_NOT_FOUND(NOT_FOUND, "5002", "기사 정보를 찾을 수 없습니다."),
 	RESERVATION_NOT_FOUND(NOT_FOUND, "5003", "예약 정보를 찾을 수 없습니다."),

--- a/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
@@ -34,7 +34,8 @@ public enum ErrorCode {
 	UNSUPPORTED_QUERY_VALUE(BAD_REQUEST, "5001", "지원하지 않는 쿼리스트링 값입니다."),
 	OWNER_NOT_FOUND(NOT_FOUND, "5002", "기사 정보를 찾을 수 없습니다."),
 	RESERVATION_NOT_FOUND(NOT_FOUND, "5003", "예약 정보를 찾을 수 없습니다."),
-	ALREADY_ASSIGNED_DRIVER(CONFLICT, "5004", "이미 드라이버가 배정된 예약입니다.");
+	ALREADY_ASSIGNED_DRIVER(CONFLICT, "5004", "이미 드라이버가 배정된 예약입니다."),
+	ALREADY_DELIVERED(CONFLICT, "5005", "이미 운송 완료된 오더입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
@@ -31,7 +31,8 @@ public enum ErrorCode {
 
 	// 오더
 	// - 전체 오더 리스트 탐색
-	UNSUPPORTED_QUERY_VALUE(BAD_REQUEST, "5001", "지원하지 않는 쿼리스트링 값입니다.");
+	UNSUPPORTED_QUERY_VALUE(BAD_REQUEST, "5001", "지원하지 않는 쿼리스트링 값입니다."),
+	OWNER_NOT_FOUND(NOT_FOUND, "5002", "기사 정보를 찾을 수 없습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 
 	//공통
 	PAGE_NOT_FOUND(NOT_FOUND, "1003", "요청한 페이지를 찾을 수 없습니다."),
+	UNAUTHORIZED_ACCESS(UNAUTHORIZED, "1004", "리소스 접근 권한이 없습니다."),
 
 	// 토큰, 유저
 	TOKEN_NOT_FOUND(UNAUTHORIZED, "2001", "요청 헤더에 토큰이 없습니다."),
@@ -46,5 +47,4 @@ public enum ErrorCode {
 		this.code = code;
 		this.message = message;
 	}
-
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
@@ -32,7 +32,9 @@ public enum ErrorCode {
 	// 오더
 	// - 전체 오더 리스트 탐색
 	UNSUPPORTED_QUERY_VALUE(BAD_REQUEST, "5001", "지원하지 않는 쿼리스트링 값입니다."),
-	OWNER_NOT_FOUND(NOT_FOUND, "5002", "기사 정보를 찾을 수 없습니다.");
+	OWNER_NOT_FOUND(NOT_FOUND, "5002", "기사 정보를 찾을 수 없습니다."),
+	RESERVATION_NOT_FOUND(NOT_FOUND, "5003", "예약 정보를 찾을 수 없습니다."),
+	ALREADY_ASSIGNED_DRIVER(CONFLICT, "5004", "이미 드라이버가 배정된 예약입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
@@ -27,7 +27,11 @@ public enum ErrorCode {
 	ACCOUNT_ALREADY_EXISTS(CONFLICT, "2007", "이미 가입된 전화번호입니다."),
 	UNREGISTERED_USER_ID(UNAUTHORIZED, "2008", "존재하지 않는 아이디입니다."),
 	USER_NOT_FOUND(NOT_FOUND, "2009", "사용자를 찾을 수 없습니다."),
-	INCORRECT_PASSWORD(UNAUTHORIZED, "2010", "비밀번호가 일치하지 않습니다.");
+	INCORRECT_PASSWORD(UNAUTHORIZED, "2010", "비밀번호가 일치하지 않습니다."),
+
+	// 오더
+	// - 전체 오더 리스트 탐색
+	UNSUPPORTED_QUERY_VALUE(BAD_REQUEST, "5001", "지원하지 않는 쿼리스트링 값입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/haul-be/src/main/java/com/hansalchai/haul/order/constants/OrderFilter.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/constants/OrderFilter.java
@@ -1,8 +1,12 @@
 package com.hansalchai.haul.order.constants;
 
+import java.util.Arrays;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+import com.hansalchai.haul.common.exceptions.BadRequestException;
+import com.hansalchai.haul.common.utils.ErrorCode;
 import com.hansalchai.haul.reservation.entity.Reservation;
 import com.hansalchai.haul.reservation.repository.ReservationRepository;
 
@@ -30,6 +34,10 @@ public enum OrderFilter {
 	public abstract Page<Reservation> execute(ReservationRepository reservationRepository, Long carId, PageRequest pageRequest);
 
 	public static OrderFilter findFilter(String sort) {
-		return valueOf(sort.toUpperCase());
+		sort = sort.toUpperCase();
+		if (!Arrays.toString(values()).contains(sort)) {
+			throw new BadRequestException(ErrorCode.UNSUPPORTED_QUERY_VALUE);
+		}
+		return valueOf(sort);
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
@@ -78,8 +78,10 @@ public class OrderController {
 
 	@PatchMapping("/status")
 	public ResponseEntity<ApiResponse<TransportStatusChange.ResponseDto>> changeTransportStatus(
+			HttpServletRequest request,
 			@Valid @RequestBody TransportStatusChange.RequestDto requestDto) {
-		TransportStatusChange.ResponseDto responseDto = orderService.changeTransportStatus(requestDto);
+		AuthenticatedUser auth = (AuthenticatedUser)request.getAttribute(AUTHENTICATE_USER);
+		TransportStatusChange.ResponseDto responseDto = orderService.changeTransportStatus(auth.getUserId(), requestDto);
 		return ResponseEntity.ok(success(GET_SUCCESS, responseDto));
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
@@ -37,8 +37,8 @@ public class OrderController {
 	@GetMapping("")
 	public ResponseEntity<ApiResponse<OrderSearchResponse>> findAll(
 			HttpServletRequest request,
-			@RequestParam("sort") String sort,
-			@PositiveOrZero @RequestParam("page") int page) {
+			@RequestParam(value = "sort", defaultValue = "default") String sort,
+			@PositiveOrZero @RequestParam(value = "page", defaultValue = "0") int page) {
 		AuthenticatedUser auth = (AuthenticatedUser)request.getAttribute(AUTHENTICATE_USER);
 		OrderSearchResponse orders = orderService.findAll(auth.getUserId(), sort, page);
 		return ResponseEntity.ok(success(GET_SUCCESS, orders));

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -2,6 +2,7 @@ package com.hansalchai.haul.order.service;
 
 import java.util.List;
 
+import static com.hansalchai.haul.common.utils.ErrorCode.*;
 import static com.hansalchai.haul.order.dto.OrderSearchResponse.*;
 import static com.hansalchai.haul.reservation.constants.TransportStatus.*;
 import static com.hansalchai.haul.reservation.service.ReservationService.*;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.hansalchai.haul.car.entity.Car;
 import com.hansalchai.haul.common.config.SmsUtil;
 
+import com.hansalchai.haul.common.exceptions.NotFoundException;
 import com.hansalchai.haul.order.constants.OrderStatusCategory;
 import com.hansalchai.haul.order.dto.ApproveRequestDto;
 import com.hansalchai.haul.order.dto.OrderResponse.OrderDTO;
@@ -51,7 +53,7 @@ public class OrderService {
 
 		// 오더 리스트 조회를 위해 기사(Owner)의 차 id 탐색
 		Owner owner = ownerRepository.findByDriverId(driverId)
-			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 owner입니다."));
+			.orElseThrow(() -> new NotFoundException(OWNER_NOT_FOUND));
 		Car car = owner.getCar();
 		Long carId = car.getCarId();
 

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -21,6 +21,7 @@ import com.hansalchai.haul.common.config.SmsUtil;
 import com.hansalchai.haul.common.exceptions.BadRequestException;
 import com.hansalchai.haul.common.exceptions.ConflictException;
 import com.hansalchai.haul.common.exceptions.NotFoundException;
+import com.hansalchai.haul.common.exceptions.UnauthorizedException;
 import com.hansalchai.haul.order.constants.OrderStatusCategory;
 import com.hansalchai.haul.order.dto.ApproveRequestDto;
 import com.hansalchai.haul.order.dto.OrderResponse.OrderDTO;
@@ -122,10 +123,16 @@ public class OrderService {
 	}
 
 	@Transactional
-	public TransportStatusChange.ResponseDto changeTransportStatus(TransportStatusChange.RequestDto requestDto) {
+	public TransportStatusChange.ResponseDto changeTransportStatus(Long userId, TransportStatusChange.RequestDto requestDto) {
 
 		Reservation reservation = reservationRepository.findById(requestDto.getId())
 			.orElseThrow(() -> new NotFoundException(RESERVATION_NOT_FOUND));
+
+		//요청한 유저 id가 예약 ownerId랑 같아야 운송 상태를 변경할 수 있다.
+		Owner owner = reservation.getOwner();
+		if (!userId.equals(owner.getOwnerId())) {
+			throw new UnauthorizedException(UNAUTHORIZED_ACCESS);
+		}
 
 		// 다음 단계의 운송 상태 가져오기(운송 전 -> 운송 중, 운송 중 -> 운송 완료)
 		Transport transport = reservation.getTransport();

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/constants/TransportStatus.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/constants/TransportStatus.java
@@ -23,15 +23,9 @@ public enum TransportStatus {
 
 	// 다음 단계의 운송 상태를 반환
 	public static TransportStatus getNextStatus(TransportStatus currentStatus) {
-
 		if (currentStatus == NOT_STARTED) {
 			return IN_PROGRESS;
 		}
-
-		if (currentStatus == IN_PROGRESS) {
-			return DONE;
-		}
-
-		return currentStatus;
+		return DONE;
 	}
 }


### PR DESCRIPTION
## 반영 브랜치
feat/#85-order-exception-handler-> BE_dev

## PR 요약
- 전체 오더 리스트 탐색, 오더 승인, 오더 운송상태 변경에 대한 예외처리
- 쿼리스트링의 기본 값 설정 -> 쿼리스트링의 value가 없어도 오류가 발생하지 않게함

## PR 설명
**1. 전체 오더 리스트 탐색 예외처리**
 - request param 중 sort에 이상한 value 넣는 경우 `400 Bad Request` (ex : ~:8080?sort=hi)
 - 오더 리스트 조회 중 기사가 조회되지 않는 경우 `404 Not Found`

**2. 오더 승인 예외처리**
 - 승인할 오더가 존재하지 않으면 `404 Not Found`
 - 오더 승인할 기사 정보가 존재하지 않으면 `404 Not Found`
 - 오더에 이미 배정된 기사가 있으면 오더 승인 불가 `409 Conflict`

**3. 오더 운송상태 변경 예외처리**
 - 운송상태를 변경할 오더가 존재하지 않으면 `404 Not Found`
 - 운송상태 변경을 요청한 유저가 오더에 배정된 기사와 일치하지 않으면 `401 Unauthorized`
 - 이미 운송 완료된 오더는 운송 상태 변경 불가 `400 Bad Request`

## ETC
Close #85 
