### PR TITLE
Fix/#150 회원 인증 기능 보완

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/handler/GlobalExceptionHandler.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/handler/GlobalExceptionHandler.java
@@ -3,18 +3,15 @@ package com.hansalchai.haul.common.handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.hansalchai.haul.common.exceptions.BadRequestException;
 import com.hansalchai.haul.common.exceptions.ConflictException;
-import com.hansalchai.haul.common.exceptions.GeneralException;
 import com.hansalchai.haul.common.exceptions.NotFoundException;
 import com.hansalchai.haul.common.exceptions.UnauthorizedException;
 import com.hansalchai.haul.common.utils.ApiResponse;
-import com.hansalchai.haul.common.utils.ErrorCode;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -22,23 +19,6 @@ import jakarta.servlet.http.HttpServletRequest;
 public class GlobalExceptionHandler {
 
 	private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
-
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	@ExceptionHandler(GeneralException.class)
-	protected ApiResponse handleCustomException(GeneralException exception, HttpServletRequest request) {
-		logInfo(request, exception.getCode().getStatus(), exception.getCode().getMessage());
-		return ApiResponse.error(exception.getCode());
-	}
-
-	// @RequestBody valid 에러
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	@ExceptionHandler(MethodArgumentNotValidException.class)
-	protected ApiResponse handleMethodArgNotValidException(MethodArgumentNotValidException exception,
-		HttpServletRequest request) {
-		String message = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
-		logInfo(request, HttpStatus.BAD_REQUEST, message);
-		return ApiResponse.error(ErrorCode.MethodArgumentNotValidException);
-	}
 
 	@ExceptionHandler(BadRequestException.class)
 	protected ApiResponse handleBadRequestException(BadRequestException exception, HttpServletRequest request) {

--- a/haul-be/src/main/java/com/hansalchai/haul/user/repository/UsersRepository.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/repository/UsersRepository.java
@@ -3,10 +3,13 @@ package com.hansalchai.haul.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.hansalchai.haul.user.entity.Users;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
 
-	Optional<Users> findByTel(String tel);
+	@Query("select u from Users u where u.tel = :tel and u.role != 'GUEST'")
+	Optional<Users> findUserByTel(@Param("tel") String tel);
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/user/service/UsersService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/service/UsersService.java
@@ -30,7 +30,7 @@ public class UsersService {
 	public Long signUp(CustomerSignUpDto signUpDto) {
 		//중복 회원가입 검증
 		String tel = signUpDto.getTel();
-		if (usersRepository.findByTel(tel).isPresent()) {
+		if (usersRepository.findUserByTel(tel).isPresent()) {
 			throw new ConflictException(ACCOUNT_ALREADY_EXISTS);
 		}
 
@@ -41,7 +41,7 @@ public class UsersService {
 	public UserLogin.ResponseDto signIn(UserLogin.RequestDto requestDto) throws JsonProcessingException {
 
 		// db에 있는(회원가입한) 유저인지 검증
-		Users user = usersRepository.findByTel(requestDto.getTel())
+		Users user = usersRepository.findUserByTel(requestDto.getTel())
 			.orElseThrow(() -> new UnauthorizedException(UNREGISTERED_USER_ID));
 
 		// 비밀번호 검증


### PR DESCRIPTION
## 반영 브랜치
ex) fix/#150-login-process -> BE_dev

## PR 요약
- 회원 인증 과정에서 회원 검증을 위한 회원 조회 쿼리 변경
- (GlobalExceptionHandler의 불필요한 코드 삭제)

## PR 설명
회원가입한 유저가 비회원으로 예약을 생성하면 user 테이블의 tel 컬럼에 중복되는 값이 생긴다.
기존 로직은 전화번호로 유저 정보를 가져온 후, 비밀번호를 비교하여 로그인한다. 이때 중복 전화번호가 있으면 유저를 특정할 수 없다.
따라서 전화번호와 함께 Role이 GUEST가 아닌 경우에만 로그인을 성공시키도록 코드를 수정했다.

## ETC
Close #150 
