### PR TITLE
Hotfix/#144 fix list

### DIFF
--- a/haul-driver-fe/src/components/InfiniteList/InfiniteList.jsx
+++ b/haul-driver-fe/src/components/InfiniteList/InfiniteList.jsx
@@ -45,7 +45,7 @@ function useIntersectionObserver(callback) {
       (entries, observer) => {
         entries.forEach(entry => {
           if (!entry.isIntersecting) return;
-          observer.unobserve(entry.target);
+          entry.target.style.display = "none";
           callback();
         });
       },
@@ -75,39 +75,30 @@ const InfiniteList = ({
   listStatus,
   emptyListView = <></>
 }) => {
-  const [isEnd, setIsEnd] = useState(() => false); //데이터를 모두 불러왔으면 end를 트리거 시키기 위한 state
+  const [isEnd, setIsEnd] = useState(false); //데이터를 모두 불러왔으면 end를 트리거 시키기 위한 state
   const realEndRef = useRef(false); //리스트를 모두 불러왔는지 확인하기 위한 ref
   const endRef = useRef(null); //마지막 요소를 참조하기 위한 ref
   const page = useRef(0); //현재 불러와진 최종 페이지
-  //const isLoading = useRef(true); //데이터를 불러오는 중이면 True
-  const [isLoading, setIsLoading] = useState(true); //데이터를 불러오는 중이면 True
+  const isLoading = useRef(true); //데이터를 불러오는 중이면 True
+  //const [isLoading, setIsLoading] = useState(true); //데이터를 불러오는 중이면 True
   const [reservationList, setReservationList] = useState([]); //현재 불러와진 예약 리스트
 
   //IntersectionObserver에 마지막 요소가 잡히면 페이지를 1 증가시킴
   const { observe, disconnect } = useIntersectionObserver(() => {
-    if (realEndRef.current) return;
+    if (isLoading.current) return;
 
     page.current += 1;
-    () =>
-      (async () => {
-        if (realEndRef.current) return;
-
-        setIsLoading(true);
-        //isLoading.current = true;
-        (async () => {
-          await runFetcher();
-        })();
-        //isLoading.current = false;
-        setIsLoading(false);
-      })();
+    if (isLoading.current) return;
+    (async () => {
+      await runFetcher();
+    })();
   });
 
   const runFetcher = async () => {
-    const fetcherIndex = () => listStatus;
     const newPage =
       typeof fetcher === "function"
         ? await fetcher({ page: page.current })
-        : await fetcher[fetcherIndex()]({ page: page.current });
+        : await fetcher[listStatus]({ page: page.current });
     if (newPage.success !== true) {
       setIsEnd(true);
       ToastMaker({
@@ -116,53 +107,29 @@ const InfiniteList = ({
       });
       return;
     }
-
+    setReservationList(prev => prev.concat(newPage.data.list));
     setIsEnd(newPage.data.lastPage);
-    setReservationList(prev => {
-      if (newPage.data.list.length !== 0) return prev.concat(newPage.data.list);
-      return prev;
-    });
+    endRef.current.style.display = (newPage.data.lastPage ? "none" : "");
   };
 
   useEffect(() => {
+    page.current = 0;
+    setReservationList([]);
+    isLoading.current = false;
+    setIsEnd(false);
     (async () => {
-      disconnect();
-      //isLoading.current = true;
-      setIsLoading(true);
-      setReservationList([]);
-
-      page.current = 0;
-      realEndRef.current = false;
-      setIsEnd(false);
-
-      (async () => {
-        await runFetcher();
-      })();
-      setIsLoading(false);
-      //isLoading.current = false;
-      //observe(endRef.current);
+      await runFetcher();
     })();
   }, [listStatus]);
 
   useEffect(() => {
     if (isEnd) {
-      //setIsLoading(true);
-      //isLoading.current = false;
-      disconnect();
-      endRef.current = null;
-      realEndRef.current = true;
+      //endRef.current = null;
     }
   }, [isEnd]);
 
   useEffect(() => {
-    if (realEndRef.current) return setIsEnd(() => false);
-    //setIsLoading(false);
-    //isLoading.current = false;
-    return () => {
-      if (endRef.current) observe(endRef.current);
-      setReservationList([]);
-      setIsEnd(() => false);
-    };
+    observe(endRef.current);
   }, []);
 
   return (
@@ -182,13 +149,10 @@ const InfiniteList = ({
           <Margin height="20px" />
         </div>
       ))}
-      {reservationList.length === 0 && isEnd ? (
-        emptyListView
-      ) : isEnd ? (
-        <ListEnd />
-      ) : (
-        <LoadingSkeleton ref={endRef} />
-      )}
+      {reservationList.length === 0 && isEnd
+        ? emptyListView
+        : isEnd && <ListEnd />}
+      <LoadingSkeleton ref={endRef} />
     </ListFrame>
   );
 };

--- a/haul-driver-fe/src/components/InfiniteList/InfiniteList.jsx
+++ b/haul-driver-fe/src/components/InfiniteList/InfiniteList.jsx
@@ -79,7 +79,8 @@ const InfiniteList = ({
   const realEndRef = useRef(false); //리스트를 모두 불러왔는지 확인하기 위한 ref
   const endRef = useRef(null); //마지막 요소를 참조하기 위한 ref
   const page = useRef(0); //현재 불러와진 최종 페이지
-  const isLoading = useRef(true); //데이터를 불러오는 중이면 True
+  //const isLoading = useRef(true); //데이터를 불러오는 중이면 True
+  const [isLoading, setIsLoading] = useState(true); //데이터를 불러오는 중이면 True
   const [reservationList, setReservationList] = useState([]); //현재 불러와진 예약 리스트
 
   //IntersectionObserver에 마지막 요소가 잡히면 페이지를 1 증가시킴
@@ -91,12 +92,13 @@ const InfiniteList = ({
       (async () => {
         if (realEndRef.current) return;
 
-        isLoading.current = true;
-        setTimeout(async () => {
+        setIsLoading(true);
+        //isLoading.current = true;
+        (async () => {
           await runFetcher();
-        }, 0);
-
-        isLoading.current = false;
+        })();
+        //isLoading.current = false;
+        setIsLoading(false);
       })();
   });
 
@@ -124,23 +126,28 @@ const InfiniteList = ({
 
   useEffect(() => {
     (async () => {
+      disconnect();
+      //isLoading.current = true;
+      setIsLoading(true);
       setReservationList([]);
 
       page.current = 0;
       realEndRef.current = false;
       setIsEnd(false);
 
-      isLoading.current = true;
-      setTimeout(async () => {
+      (async () => {
         await runFetcher();
-      }, 0);
-      isLoading.current = false;
+      })();
+      setIsLoading(false);
+      //isLoading.current = false;
+      //observe(endRef.current);
     })();
   }, [listStatus]);
 
   useEffect(() => {
     if (isEnd) {
-      isLoading.current = true;
+      //setIsLoading(true);
+      //isLoading.current = false;
       disconnect();
       endRef.current = null;
       realEndRef.current = true;
@@ -149,7 +156,8 @@ const InfiniteList = ({
 
   useEffect(() => {
     if (realEndRef.current) return setIsEnd(() => false);
-    isLoading.current = false;
+    //setIsLoading(false);
+    //isLoading.current = false;
     return () => {
       if (endRef.current) observe(endRef.current);
       setReservationList([]);
@@ -159,29 +167,25 @@ const InfiniteList = ({
 
   return (
     <ListFrame>
-      {reservationList.length === 0
-        ? emptyListView
-        : reservationList.map((data, index) => (
-            <div key={`reserv${index}`}>
-              <Link to={`${baseURL}/${data.orderId}`} key={`reserv${index}`}>
-                <SummaryItemBox
-                  index={index}
-                  selectedStatus={listStatus}
-                  src={data.src}
-                  dst={data.dst}
-                  time={data.time}
-                  fee={data.cost}
-                />
-              </Link>
-              <Margin height="20px" />
-            </div>
-          ))}
-      {isEnd ? (
-        reservationList.length === 0 ? (
-          <></>
-        ) : (
-          <ListEnd />
-        )
+      {reservationList.map((data, index) => (
+        <div key={`reserv${index}`}>
+          <Link to={`${baseURL}/${data.orderId}`} key={`reserv${index}`}>
+            <SummaryItemBox
+              index={index}
+              selectedStatus={listStatus}
+              src={data.src}
+              dst={data.dst}
+              time={data.time}
+              fee={data.cost}
+            />
+          </Link>
+          <Margin height="20px" />
+        </div>
+      ))}
+      {reservationList.length === 0 && isEnd ? (
+        emptyListView
+      ) : isEnd ? (
+        <ListEnd />
       ) : (
         <LoadingSkeleton ref={endRef} />
       )}

--- a/haul-driver-fe/src/components/InfiniteList/InfiniteList.jsx
+++ b/haul-driver-fe/src/components/InfiniteList/InfiniteList.jsx
@@ -19,7 +19,7 @@ const LoadingSkeleton = forwardRef((props, ref) => {
 
 const ListFrame = styled.div`
   width: 100%;
-  height: 100%;
+  height: fit-content;
   ${({ theme }) => theme.flex.flexColumn};
   padding-bottom: 100px;
 `;

--- a/haul-driver-fe/src/data/GlobalVariable.js
+++ b/haul-driver-fe/src/data/GlobalVariable.js
@@ -17,6 +17,6 @@ export const ErrorMessageMap = {
   IsNotNumber: "숫자만 입력 가능합니다.",
   IsNotPositiveNumber: "0 이하는 입력 불가능합니다.",
   IsNotMinPasswordCount: "8자리 이상의 비밀번호만 가능합니다.",
-  NoUserFound: "사용자 정보를 찾을 수 없었어요.",
+  NoUserFound: "사용자 정보를 찾을 수 없습니다.",
   TryLater: "잠시 후 다시 시도해주세요."
 };

--- a/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckList/ScheduleCheckList.jsx
+++ b/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckList/ScheduleCheckList.jsx
@@ -13,8 +13,24 @@ import { functionBinder } from "../../../utils/helper.js";
 import { getUserName } from "../../../utils/localStorage.js";
 import Typography from "../../../components/Typhography/Typhography.jsx";
 import EmptyListHolder from "./EmptyListHolder.jsx";
+import styled from "styled-components";
 
-//TODO: API가 운송상태를 구별하여 가져올 수 있게 변경된 후 리스트 수정할 것!
+const Floater = styled.div`
+  overflow: visible;
+  height: fit-content;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  z-index: 10;
+  background-color: white;
+`;
+
+const HorizontalLine = styled(UnderBar)`
+  width: 100%;
+  left: -20px;
+  position: relative;
+`;
+
 const ScheduleCheckList = () => {
   const [selectedStatus, setSelectedStatus] = useState(0);
   const driverName = getUserName();
@@ -27,20 +43,22 @@ const ScheduleCheckList = () => {
 
   return (
     <MobileLayout>
-      <Header home={false} back={false}>
-        <Typography font="bold24">
-          <TypographySpan color="subColor">{driverName}</TypographySpan>님의
-          일정<TypographySpan color="subColor"> .</TypographySpan>
-        </Typography>
-      </Header>
-      <Margin height="32px" />
-      <TabBar
-        tabBarList={statusList}
-        setSelected={setSelectedStatus}
-        selected={selectedStatus}
-      />
-      <UnderBar />
-      <Margin height="20px" />
+      <Floater>
+        <Header home={false} back={false}>
+          <Typography font="bold24">
+            <TypographySpan color="subColor">{driverName}</TypographySpan>님의
+            일정<TypographySpan color="subColor"> .</TypographySpan>
+          </Typography>
+        </Header>
+        <Margin height="32px" />
+        <TabBar
+          tabBarList={statusList}
+          setSelected={setSelectedStatus}
+          selected={selectedStatus}
+        />
+        <HorizontalLine />
+      </Floater>
+      <Margin height="110px" />
       <InfiniteList
         fetcher={fetcherList}
         listStatus={selectedStatus}

--- a/haul-driver-fe/src/views/ScheduleCreate/ScheduleCreateList/ScheduleCreateList.jsx
+++ b/haul-driver-fe/src/views/ScheduleCreate/ScheduleCreateList/ScheduleCreateList.jsx
@@ -13,8 +13,24 @@ import { functionBinder } from "../../../utils/helper.js";
 import Typography from "../../../components/Typhography/Typhography.jsx";
 import { getUserName } from "../../../utils/localStorage.js";
 import EmptyListHolder from "./EmptyListHolder.jsx";
+import styled from "styled-components";
 
-//TODO: API가 운송상태를 구별하여 가져올 수 있게 변경된 후 리스트 수정할 것!
+const Floater = styled.div`
+  overflow: visible;
+  height: fit-content;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  z-index: 10;
+  background-color: white;
+`;
+
+const HorizontalLine = styled(UnderBar)`
+  width: 100%;
+  left: -20px;
+  position: relative;
+`;
+
 const ScheduleCreateList = () => {
   const [selectedStatus, setSelectedStatus] = useState(0);
   const driverName = getUserName();
@@ -28,20 +44,22 @@ const ScheduleCreateList = () => {
 
   return (
     <MobileLayout>
-      <Header home={false} back={false}>
-        <Typography font="bold24">
-          <TypographySpan color="subColor">{driverName}</TypographySpan>님을
-          위한 일정잡기<TypographySpan color="subColor"> .</TypographySpan>
-        </Typography>
-      </Header>
-      <Margin height="32px" />
-      <TabBar
-        tabBarList={statusList}
-        setSelected={setSelectedStatus}
-        selected={selectedStatus}
-      />
-      <UnderBar />
-      <Margin height="20px" />
+      <Floater>
+        <Header home={false} back={false}>
+          <Typography font="bold24">
+            <TypographySpan color="subColor">{driverName}</TypographySpan>님을
+            위한 일정잡기<TypographySpan color="subColor"> .</TypographySpan>
+          </Typography>
+        </Header>
+        <Margin height="32px" />
+        <TabBar
+          tabBarList={statusList}
+          setSelected={setSelectedStatus}
+          selected={selectedStatus}
+        />
+        <HorizontalLine />
+      </Floater>
+      <Margin height="110px" />
       <InfiniteList
         fetcher={fetcherList}
         listStatus={selectedStatus}


### PR DESCRIPTION
## 반영 브랜치
hotfix/#144-fix-list -> FE_Driver_dev

## PR 요약
- 리스트 페이지로 이동 시 여러번 fetch 되는 문제 수정
- 리스트가 끝나지 않았는데도 추가로 로드되지 않던 문제 수정
- 리스트 페이지에서 탭바를 상단에 고정

## PR 설명
리스트 페이지로 이동할 때와 리스트 페이지에서 나갈 때 서버로 추가적인 요청을 보내던 문제가 수정되었습니다.
리스트가 끝나지 않았는데 추가로 로드되지 않고 스켈레톤 이미지가 사라지던 문제가 수정되었습니다.
빈 리스트 아이콘이 리스트가 첫 로드되는 순간에 나타나는 문제가 수정되었습니다.
리스트에 요소가 존재하느냐에 따라 탭바의 위치가 달라지던 문제가 수정되었습니다.
리스트 페이지의 헤더와 탭바가 상단에 고정되었습니다.