### PR TITLE
fix/#160 토큰 관련 에러 코드 수정

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/jwt/JwtProvider.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/jwt/JwtProvider.java
@@ -90,16 +90,11 @@ public class JwtProvider {
 	public void validateToken(String token) {
 		try {
 			getClaims(token);
-		} catch (SignatureException exception) {
-			throw new UnauthorizedException(INVALID_JWT_SIGNATURE);
-		} catch (MalformedJwtException exception) {
+		} catch (MalformedJwtException | SignatureException | UnsupportedJwtException | IllegalArgumentException exception) {
+			exception.printStackTrace();
 			throw new UnauthorizedException(INVALID_TOKEN);
 		} catch (ExpiredJwtException exception) {
 			throw new UnauthorizedException(EXPIRED_TOKEN);
-		} catch (UnsupportedJwtException exception) {
-			throw new UnauthorizedException(UNSUPPORTED_JWT_TOKEN);
-		} catch (IllegalArgumentException exception) {
-			throw new UnauthorizedException(EMPTY_JWT);
 		}
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
@@ -29,12 +29,9 @@ public enum ErrorCode {
 	TOKEN_NOT_FOUND(UNAUTHORIZED, 2001, "요청 헤더에 토큰이 없습니다."),
 	INVALID_TOKEN(UNAUTHORIZED, 2002, "토큰 유효성 검증에 실패했습니다."),
 	EXPIRED_TOKEN(UNAUTHORIZED, 2003, "토큰이 만료되었습니다."),
-	INVALID_JWT_SIGNATURE(UNAUTHORIZED, 2004, "JWT 서명이 유효하지 않습니다"),
-	UNSUPPORTED_JWT_TOKEN(UNAUTHORIZED, 2005, "지원되지 않는 형식의 토큰입니다."),
-	EMPTY_JWT(UNAUTHORIZED, 2006, "JWT Claim이 비어있습니다."),
-	ACCOUNT_ALREADY_EXISTS(CONFLICT, 2007, "이미 가입된 전화번호입니다."),
-	UNREGISTERED_USER_ID(UNAUTHORIZED, 2008, "존재하지 않는 아이디입니다."),
-	INCORRECT_PASSWORD(UNAUTHORIZED, 2009, "비밀번호가 일치하지 않습니다."),
+	ACCOUNT_ALREADY_EXISTS(CONFLICT, 2004, "이미 가입된 전화번호입니다."),
+	UNREGISTERED_USER_ID(UNAUTHORIZED, 2005, "존재하지 않는 아이디입니다."),
+	INCORRECT_PASSWORD(UNAUTHORIZED, 2006, "비밀번호가 일치하지 않습니다."),
 
 	//예약
 	INVALID_RESERVATION_STATE_CHANGE (FORBIDDEN, 3001, "관리자 권한이 아닐 경우 예약 전 상태에서만 상태를 변경할 수 있습니다."),


### PR DESCRIPTION
## 반영 브랜치
fix/#160-modify-token-error-code -> BE_dev

## PR 요약
- 토큰 관련 에러 코드 수정

## PR 설명
클라이언트 측에선 토큰 관련 에러를 세세하게 제공해줄 필요가 없다. 
따라서 서버에서만 예외별로 로그를 출력하고 클라이언트에겐 공통된 응답을 전송하도록 수정했다.

## ETC
Close #160 
