### PR TITLE
fix : 토큰 예외처리 방식 수정

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/JwtValidationFilter.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/JwtValidationFilter.java
@@ -61,7 +61,7 @@ public class JwtValidationFilter implements Filter {
 
 		// 토큰 복호화 및 검증
 		String accessToken = jwtProvider.resolveToken(httpServletRequest);
-		jwtProvider.validateToken(accessToken);
+		jwtProvider.validateToken(httpServletResponse, accessToken);
 
 		// 검증 성공 시, 요청에 AUTHENTICATE_USER attribute 추가
 		request.setAttribute(AUTHENTICATE_USER, getAuthenticateUser(accessToken));

--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/jwt/JwtProvider.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/jwt/JwtProvider.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.hansalchai.haul.common.exceptions.UnauthorizedException;
+import com.hansalchai.haul.common.auth.handler.FilterExceptionHandler;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -22,6 +22,7 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -87,14 +88,14 @@ public class JwtProvider {
 		return header.split(" ")[1];
 	}
 
-	public void validateToken(String token) {
+	public void validateToken(HttpServletResponse response, String token) {
 		try {
 			getClaims(token);
 		} catch (MalformedJwtException | SignatureException | UnsupportedJwtException | IllegalArgumentException exception) {
 			exception.printStackTrace();
-			throw new UnauthorizedException(INVALID_TOKEN);
+			FilterExceptionHandler.sendError(response, INVALID_TOKEN);
 		} catch (ExpiredJwtException exception) {
-			throw new UnauthorizedException(EXPIRED_TOKEN);
+			FilterExceptionHandler.sendError(response, EXPIRED_TOKEN);
 		}
 	}
 }


### PR DESCRIPTION
## 반영 브랜치
fix/#164-token-exception-handling -> BE_dev

## PR 요약
- 토큰 예외처리 방식 수정

## PR 설명
필터에서 발생한 예외는 `GlobalExceptionHandler`에서 감지할 수 없습니다.
따라서 `FilterExceptionHandler`에서 오류 발생 응답을 보낼 수 있도록 코드를 수정했습니다.

## ETC
Close #164 
