### PR TITLE
Feat/#149 오더 승인 기능 보완 - 중첩 스케줄 방지

### DIFF
--- a/haul-be/build.gradle
+++ b/haul-be/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.hansalchai'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'

--- a/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
@@ -39,7 +39,8 @@ public enum ErrorCode {
 
 	// 오더
 	ALREADY_ASSIGNED_DRIVER(CONFLICT, 4001, "이미 드라이버가 배정된 예약입니다."),
-	ALREADY_DELIVERED(CONFLICT, 4002, "이미 운송 완료된 오더입니다.");
+	ALREADY_DELIVERED(CONFLICT, 4002, "이미 운송 완료된 오더입니다."),
+	SCHEDULE_CONFLICT(CONFLICT, 4003, "해당 오더와 시간이 겹치는 다른 오더가 있습니다.");
 
 
 

--- a/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,6 +32,7 @@ public class OrderController {
 
 	private final OrderService orderService;
 	private static final String V1_ORDERS_PATH = "/api/v1/orders";
+	private static final String V2_ORDERS_PATH = "/api/v2/orders";
 
 	@GetMapping(V1_ORDERS_PATH)
 	public ResponseEntity<ApiResponse<OrderSearchResponse>> findAll(
@@ -83,5 +83,14 @@ public class OrderController {
 		AuthenticatedUser auth = (AuthenticatedUser)request.getAttribute(AUTHENTICATE_USER);
 		TransportStatusChange.ResponseDto responseDto = orderService.changeTransportStatus(auth.getUserId(), requestDto);
 		return ResponseEntity.ok(success(GET_SUCCESS, responseDto));
+	}
+
+	@PatchMapping(V2_ORDERS_PATH + "/approve")
+	public ResponseEntity<ApiResponse<Object>> approveOrderV2(
+			HttpServletRequest request,
+			@Valid @RequestBody ApproveRequestDto approveRequestDto) {
+		AuthenticatedUser auth = (AuthenticatedUser)request.getAttribute(AUTHENTICATE_USER);
+		orderService.approveV2(auth.getUserId(), approveRequestDto);
+		return ResponseEntity.ok(success(GET_SUCCESS, null));
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -115,9 +115,10 @@ public class OrderService {
 		LocalDateTime newOrderStartDateTime = LocalDateTime.of(newOrder.getDate(), newOrder.getTime());
 		LocalDateTime newOrderEndDateTime = newOrderStartDateTime.plusMinutes(requiredTime);
 
-		LocalDate date = newOrder.getDate();
+		// 기사 스케줄 리스트 조회
+		LocalDate today = newOrder.getDate();
 		List<Reservation> myOrders
-			= reservationRepository.findScheduleOfDriver(driverId, date.minusDays(1), date.plusDays(1));
+			= reservationRepository.findScheduleOfDriver(driverId, today.minusDays(1), today);
 
 		for (Reservation myOrder : myOrders) {
 			requiredTime = (long)(myOrder.getTransport().getRequiredTime() * 60);

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -1,5 +1,7 @@
 package com.hansalchai.haul.order.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.hansalchai.haul.common.utils.ErrorCode.*;
@@ -22,7 +24,6 @@ import com.hansalchai.haul.common.exceptions.BadRequestException;
 import com.hansalchai.haul.common.exceptions.ConflictException;
 import com.hansalchai.haul.common.exceptions.ForbiddenException;
 import com.hansalchai.haul.common.exceptions.NotFoundException;
-import com.hansalchai.haul.common.exceptions.UnauthorizedException;
 import com.hansalchai.haul.order.constants.OrderStatusCategory;
 import com.hansalchai.haul.order.dto.ApproveRequestDto;
 import com.hansalchai.haul.order.dto.OrderResponse.OrderDTO;
@@ -79,22 +80,25 @@ public class OrderService {
 	}
 
 	@Transactional
-	public void approve(Long driverId, ApproveRequestDto approveRequestDto) {
+	public void approve(Long userId, ApproveRequestDto approveRequestDto) {
 
-		// 1. 예약 정보 가져오기
 		Reservation reservation = reservationRepository.findById(approveRequestDto.getId())
 			.orElseThrow(() -> new NotFoundException(RESERVATION_NOT_FOUND));
 
-		// 1.5. 기사가 배정되어있으면 오더 승인 불가
+		// 기사가 배정되어있으면 오더 승인 불가
 		if (reservation.getOwner() != null) {
 			throw new ConflictException(ALREADY_ASSIGNED_DRIVER);
 		}
 
-		// 2. 기사 정보 가져오기
-		Owner owner = ownerRepository.findByDriverId(driverId)
+		Owner owner = ownerRepository.findByDriverId(userId)
 			.orElseThrow(() -> new NotFoundException(OWNER_NOT_FOUND));
 
-		// 3. 예약에 기사 배정 정보 저장, 운송 상태를 '운송 전'으로 변경
+		// 겹치는 오더가 있으면 오더 승인 불가
+		if (isScheduleOverlap(owner.getOwnerId(), reservation)) {
+			throw new ConflictException(SCHEDULE_CONFLICT);
+		}
+
+		// 예약에 기사 배정 정보 저장, 운송 상태를 '운송 전'으로 변경
 		reservation.setDriver(owner);
 		Transport transport = reservation.getTransport();
 		transport.updateTransportStatus(NOT_STARTED);
@@ -104,6 +108,31 @@ public class OrderService {
 		String reservationNumber = reservation.getNumber();
 		smsUtil.send(customerTel, reservationNumber);
 	}
+
+	private boolean isScheduleOverlap(Long driverId, Reservation newOrder) {
+
+		long requiredTime = (long)(newOrder.getTransport().getRequiredTime() * 60);
+		LocalDateTime newOrderStartDateTime = LocalDateTime.of(newOrder.getDate(), newOrder.getTime());
+		LocalDateTime newOrderEndDateTime = newOrderStartDateTime.plusMinutes(requiredTime);
+
+		LocalDate date = newOrder.getDate();
+		List<Reservation> myOrders
+			= reservationRepository.findScheduleOfDriver(driverId, date.minusDays(1), date.plusDays(1));
+
+		for (Reservation myOrder : myOrders) {
+			requiredTime = (long)(myOrder.getTransport().getRequiredTime() * 60);
+			LocalDateTime myOrderStartDateTime = LocalDateTime.of(myOrder.getDate(), myOrder.getTime());
+			LocalDateTime myOrderEndDateTime = myOrderStartDateTime.plusMinutes(requiredTime);
+
+			// 스케줄이 중첩되는 경우
+			if (!((newOrderStartDateTime.isBefore(myOrderStartDateTime) && newOrderEndDateTime.isBefore(myOrderStartDateTime)) ||
+				(newOrderStartDateTime.isAfter(myOrderEndDateTime) && newOrderEndDateTime.isAfter(myOrderEndDateTime)))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	@Transactional
 	public OrderDTO getOrder(String keyword, int page, Long userId) {
 		Users user = usersRepository.findById(userId)

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -129,9 +129,9 @@ public class OrderService {
 		transport.updateTransportStatus(NOT_STARTED);
 
 		// 4. 배정 알림을 고객에게 sms로 전송
-		String customerTel = reservation.getUser().getTel();
-		String reservationNumber = reservation.getNumber();
-		smsUtil.send(customerTel, reservationNumber);
+		// String customerTel = reservation.getUser().getTel();
+		// String reservationNumber = reservation.getNumber();
+		// smsUtil.send(customerTel, reservationNumber);
 	}
 
 	private boolean isScheduleOverlap(Long driverId, Reservation newOrder) {

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -104,9 +104,9 @@ public class OrderService {
 		transport.updateTransportStatus(NOT_STARTED);
 
 		// 4. 배정 알림을 고객에게 sms로 전송
-		String customerTel = reservation.getUser().getTel();
-		String reservationNumber = reservation.getNumber();
-		smsUtil.send(customerTel, reservationNumber);
+		// String customerTel = reservation.getUser().getTel();
+		// String reservationNumber = reservation.getNumber();
+		// smsUtil.send(customerTel, reservationNumber);
 	}
 
 	private boolean isScheduleOverlap(Long driverId, Reservation newOrder) {

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -93,6 +93,31 @@ public class OrderService {
 		Owner owner = ownerRepository.findByDriverId(userId)
 			.orElseThrow(() -> new NotFoundException(OWNER_NOT_FOUND));
 
+		// 예약에 기사 배정 정보 저장, 운송 상태를 '운송 전'으로 변경
+		reservation.setDriver(owner);
+		Transport transport = reservation.getTransport();
+		transport.updateTransportStatus(NOT_STARTED);
+
+		// 4. 배정 알림을 고객에게 sms로 전송
+		// String customerTel = reservation.getUser().getTel();
+		// String reservationNumber = reservation.getNumber();
+		// smsUtil.send(customerTel, reservationNumber);
+	}
+
+	@Transactional
+	public void approveV2(Long userId, ApproveRequestDto approveRequestDto) {
+
+		Reservation reservation = reservationRepository.findById(approveRequestDto.getId())
+			.orElseThrow(() -> new NotFoundException(RESERVATION_NOT_FOUND));
+
+		// 기사가 배정되어있으면 오더 승인 불가
+		if (reservation.getOwner() != null) {
+			throw new ConflictException(ALREADY_ASSIGNED_DRIVER);
+		}
+
+		Owner owner = ownerRepository.findByDriverId(userId)
+			.orElseThrow(() -> new NotFoundException(OWNER_NOT_FOUND));
+
 		// 겹치는 오더가 있으면 오더 승인 불가
 		if (isScheduleOverlap(owner.getOwnerId(), reservation)) {
 			throw new ConflictException(SCHEDULE_CONFLICT);
@@ -104,9 +129,9 @@ public class OrderService {
 		transport.updateTransportStatus(NOT_STARTED);
 
 		// 4. 배정 알림을 고객에게 sms로 전송
-		// String customerTel = reservation.getUser().getTel();
-		// String reservationNumber = reservation.getNumber();
-		// smsUtil.send(customerTel, reservationNumber);
+		String customerTel = reservation.getUser().getTel();
+		String reservationNumber = reservation.getNumber();
+		smsUtil.send(customerTel, reservationNumber);
 	}
 
 	private boolean isScheduleOverlap(Long driverId, Reservation newOrder) {

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/repository/ReservationRepository.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/repository/ReservationRepository.java
@@ -1,5 +1,7 @@
 package com.hansalchai.haul.reservation.repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -64,4 +66,14 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 			+ "and cast(r.date || ' ' || r.time AS timestamp) > current_timestamp "
 		+ "order by r.date, r.time")
 	Page<Reservation> findAllOrderByDateTime(@Param("carId") Long carId, Pageable pageable);
+
+	@Query("select r "
+		+ "from Reservation r "
+		+ "where r.owner.ownerId = :driverId "
+		+ "and r.date between :prevDate and :nextDate "
+		+ "and r.transport.transportStatus in ('NOT_STARTED', 'IN_PROGRESS')")
+	List<Reservation> findScheduleOfDriver(
+		@Param("driverId") Long driverId,
+		@Param("prevDate") LocalDate prevDate,
+		@Param("nextDate") LocalDate nextDate);
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/repository/ReservationRepository.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/repository/ReservationRepository.java
@@ -70,10 +70,10 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	@Query("select r "
 		+ "from Reservation r "
 		+ "where r.owner.ownerId = :driverId "
-		+ "and r.date between :prevDate and :nextDate "
+		+ "and r.date between :prevDate and :today "
 		+ "and r.transport.transportStatus in ('NOT_STARTED', 'IN_PROGRESS')")
 	List<Reservation> findScheduleOfDriver(
 		@Param("driverId") Long driverId,
 		@Param("prevDate") LocalDate prevDate,
-		@Param("nextDate") LocalDate nextDate);
+		@Param("today") LocalDate today);
 }


### PR DESCRIPTION
## 반영 브랜치
feat/#149-avoid-overlap-order -> BE_dev

## PR 요약
- 오더 승인 api에 중첩 스케줄 승인 방지 기능 추가
- 기능 고도화, 성능 개선을 위해 프로젝트 버전을 0.0.1 -> 0.0.2로 변경

## PR 설명
### 중첩 스케줄 방지 프로세스
1. 예약 시간을 스케줄 시작 시간, 예약 시간 + 운송 소요 시간을 스케줄 종료 시간으로 한다.
2. 운송이 완료되지 않았으면서, 승인하려는 오더 날짜(전날 + 당일)에 부합하는 오더 리스트 조회
3. 일정이 겹치면 409 Conflict를 응답
`SCHEDULE_CONFLICT(CONFLICT, 4003, "해당 오더와 시간이 겹치는 다른 오더가 있습니다.")`

### 스케줄 중첩 케이스
1. 스케줄 일부 중첩됨
2. 스케줄이 완전 똑같이 중첩됨
3. 스케줄 시간 안에 승인하려는 오더가 중첩됨
<img width="450" alt="image" src="https://github.com/softeerbootcamp-3rd/Team4-HansalChai/assets/68904755/b889eaf5-0a0d-4dc8-9af2-6e6612e5b060">

따라서 승인하려는 오더 일정이 기존 스케줄 시작 일정의 앞이나 종료 일정 뒤에 위치하는 경우에만 승인 가능하다.

### 운송 중 날짜가 변경되는 오더 고려
기존 중첩 스케줄 방지 기능은 승인하려는 오더의 날짜에 해당하는 스케줄만 조회해서 스케줄의 중첩을 확인했습니다.
그러나 이 방식은 다음과 같은 문제점이 있습니다.

예를 들어 `운송 시작 - 2/20 18:00, 예상 소요 시간 - 7시간`인 오더 A를 승인한 상태라고 가정합니다.
이때 `운송 시작 - 2/21 00:30, 예상 소요 시간 - 1시간`인 오더 B를 승인하려합니다.
그럼 기존 로직에선 21일에 해당하는 스케줄만 조회하기 때문에 오더 A는 조회되지 않아 승인이 가능합니다. 그러나 오더 A의 종료시간은 2/21 01:00이므로 오더 B의 스케줄과 겹칩니다.

이러한 중첩을 막기 위해 승인하려는 오더의 날짜를 기준으로 전 날과 당일의 스케줄을 함께 조회하여 운송 중 날짜가 변경되는 오더도 고려할 수 있도록 수정했습니다.

### 기사 스케줄 리스트 조회 시, 전날 + 당일 오더만 조회
기존 방식은 기사 스케줄 리스트 조회 시, 승인하려는 오더 날짜의 ±1일에 해당하는 스케줄을 조회했습니다. 그러나 당일을 넘겨 다음날까지 진행되는 오더는 시작 날짜가 당일이므로 스케줄 종료 일정이 다음날이어도 스케줄 중첩을 확인할 필요가 없습니다. 따라서 기사 스케줄은 전날 + 당일에 해당하는 오더만 조회하도록 수정했습니다.
참고 : 4226013


## ETC
Close #149 
