### PR TITLE
fix : 토큰 유효성 검증 실패 시, 500 Internal Server Error가 발생하는 오류 해결

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/handler/FilterExceptionHandler.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/handler/FilterExceptionHandler.java
@@ -19,6 +19,8 @@ public class FilterExceptionHandler {
 		response.setStatus(errorCode.getStatus().value());
 		response.setContentType("application/json");
 		response.setCharacterEncoding("UTF-8");
+		String logMessage = String.format("JwtValidationFilter : %s - %s", errorCode.getStatus(),  errorCode.getMessage());
+		log.info(logMessage);
 		try {
 			String json = new ObjectMapper().writeValueAsString(ApiResponse.error(errorCode));
 			response.getWriter().write(json);

--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/jwt/JwtProvider.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/jwt/JwtProvider.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.hansalchai.haul.common.auth.handler.FilterExceptionHandler;
+import com.hansalchai.haul.common.utils.ErrorCode;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -22,7 +22,6 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -88,14 +87,16 @@ public class JwtProvider {
 		return header.split(" ")[1];
 	}
 
-	public void validateToken(HttpServletResponse response, String token) {
+	public ErrorCode validateToken(String token) {
 		try {
 			getClaims(token);
+			return null;
 		} catch (MalformedJwtException | SignatureException | UnsupportedJwtException | IllegalArgumentException exception) {
 			exception.printStackTrace();
-			FilterExceptionHandler.sendError(response, INVALID_TOKEN);
+			return INVALID_TOKEN;
 		} catch (ExpiredJwtException exception) {
-			FilterExceptionHandler.sendError(response, EXPIRED_TOKEN);
+			exception.printStackTrace();
+			return EXPIRED_TOKEN;
 		}
 	}
 }


### PR DESCRIPTION
## 반영 브랜치
fix/#173-invalid-token-send-500-error -> BE_dev

## PR 요약
- 토큰 유효성 검사 실패 시, 다음 로직을 실행하지 않도록 코드 수정

## PR 설명
500 에러가 던져진 이유는 `FilterHandlerException`에서 에러 응답을 보낸 뒤, 예외를 throw 했을 때처럼 로직이 중단되지 않고 다음 로직이 이어서 실행되기 때문이었습다. 따라서 토큰이 유효하지 않으면 다음 로직을 실행할 수 없도록 코드를 수정했습니다.

## ETC
Close #173 
