### PR TITLE
Hotfix 토큰 유효성 검증 실패 시, 에러코드 전송에 NPE 에러 해결

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/JwtValidationFilter.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/JwtValidationFilter.java
@@ -63,14 +63,16 @@ public class JwtValidationFilter implements Filter {
 		String accessToken = jwtProvider.resolveToken(httpServletRequest);
 		ErrorCode errorCode = jwtProvider.validateToken(accessToken);
 
-		// 검증 성공 시, 요청에 AUTHENTICATE_USER attribute 추가
-		if (isTokenValid(errorCode)) {
-			request.setAttribute(AUTHENTICATE_USER, getAuthenticateUser(accessToken));
-			chain.doFilter(request, response);
+		// 유효성 검증 실패 시, 에러코드 응답
+		if (isInvalidToken(errorCode)) {
+			FilterExceptionHandler.sendError(httpServletResponse, errorCode);
+			return;
 		}
 
-		// 유효성 검증 실패 시, 에러코드 응답
-		FilterExceptionHandler.sendError(httpServletResponse, errorCode);
+		// 검증 성공 시, 요청에 AUTHENTICATE_USER attribute 추가
+		request.setAttribute(AUTHENTICATE_USER, getAuthenticateUser(accessToken));
+
+		chain.doFilter(request, response);
 	}
 
 	private boolean isPrefilghtRequest(HttpServletRequest request) {
@@ -95,7 +97,7 @@ public class JwtValidationFilter implements Filter {
 		return objectMapper.readValue(authenticateUserJson, AuthenticatedUser.class);
 	}
 
-	private boolean isTokenValid(ErrorCode errorCode) {
-		return errorCode == null;
+	private boolean isInvalidToken(ErrorCode errorCode) {
+		return errorCode != null;
 	}
 }


### PR DESCRIPTION
## 반영 브랜치
hotfix/filter-error -> BE_dev

## PR 요약
토큰 유효성 검증 실패 시, 에러코드 전송에 NPE 에러 해결

## PR 설명
문제 상황 : sendError() 동작 시, errorCode.getStatus().value()에서 NPE가 발생했다. 
원인 : 토큰 유효성 검증 성공 후 return을 하지 않아서 errorCode가 null인 경우 doFilter 다음에 sendError도 실행되어서 발생
해결 : 따라서 doFilter 후 return 해서 다음 로직이 실행되지 않도록 수정