### PR TITLE
Hotfix/#179 reservation list error handling

### DIFF
--- a/haul-fe/src/main.jsx
+++ b/haul-fe/src/main.jsx
@@ -2,8 +2,4 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 
-ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+ReactDOM.createRoot(document.getElementById("root")).render(<App />);

--- a/haul-fe/src/views/Check/List/Check.jsx
+++ b/haul-fe/src/views/Check/List/Check.jsx
@@ -60,7 +60,7 @@ const Check = () => {
         />
         <HorizontalLine />
       </Floater>
-      <Margin height="10px" />
+      <Margin height="120px" />
       <InfiniteList
         fetcher={fetcherList}
         listStatus={selectedStatus}


### PR DESCRIPTION
## 반영 브랜치
hotfix/#179-reservation-list-error-handling -> FE_dev

## PR 요약
- ReactStrictMode 제거 
- 예약 리스트 페이지에서 헤더 문제 해결

## PR 설명
- ReactStrictMode 제거 
- 예약 리스트 페이지에서 헤더에 요소가 안보이는 문제 해결하였습니다
