### PR TITLE
Feat/#190 로그인 기능 보완

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/JwtValidationFilter.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/JwtValidationFilter.java
@@ -32,7 +32,9 @@ public class JwtValidationFilter implements Filter {
 	private final ObjectMapper objectMapper;
 
 	private final String[] whiteListUris
-		= new String[] {"/api/v1/users/sign-in", "/api/v1/users/sign-up", "/auth/refresh/token", "*/h2-console*", "/swagger-ui/**", "*/api-docs*", "/api/v1/reservations/guest*"};
+		= new String[] {"/api/v1/users/sign-in", "/api/v1/users/sign-up", "/auth/refresh/token",
+		"/api/v2/users/customers/sign-in", "/api/v2/users/drivers/sign-in",
+		"*/h2-console*", "/swagger-ui/**", "*/api-docs*", "/api/v1/reservations/guest*"};
 
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws

--- a/haul-be/src/main/java/com/hansalchai/haul/common/handler/GlobalExceptionHandler.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/handler/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
 package com.hansalchai.haul.common.handler;
 
+import static org.springframework.http.HttpStatus.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.hansalchai.haul.common.exceptions.BadRequestException;
@@ -14,6 +16,7 @@ import com.hansalchai.haul.common.exceptions.InternalServerError;
 import com.hansalchai.haul.common.exceptions.NotFoundException;
 import com.hansalchai.haul.common.exceptions.UnauthorizedException;
 import com.hansalchai.haul.common.utils.ApiResponse;
+import com.hansalchai.haul.common.utils.ErrorCode;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -21,6 +24,14 @@ import jakarta.servlet.http.HttpServletRequest;
 public class GlobalExceptionHandler {
 
 	private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ApiResponse<Object> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception, HttpServletRequest request) {
+		exception.printStackTrace();
+		ErrorCode errorCode = ErrorCode.INVALID_DATA;
+		logInfo(request, BAD_REQUEST, errorCode.getMessage());
+		return ApiResponse.error(errorCode);
+	}
 
 	@ExceptionHandler(BadRequestException.class)
 	protected ApiResponse<Object> handleBadRequestException(BadRequestException exception, HttpServletRequest request) {
@@ -33,7 +44,7 @@ public class GlobalExceptionHandler {
 	protected ApiResponse<Object> handleUnauthorizedException(
 			UnauthorizedException exception,
 			HttpServletRequest request) {
-		logInfo(request, HttpStatus.UNAUTHORIZED, exception.getMessage());
+		logInfo(request, UNAUTHORIZED, exception.getMessage());
 		return ApiResponse.error(exception.getCode());
 	}
 
@@ -42,7 +53,7 @@ public class GlobalExceptionHandler {
 	protected ApiResponse<Object> handleForbiddenException(
 		ForbiddenException exception,
 		HttpServletRequest request) {
-		logInfo(request, HttpStatus.FORBIDDEN, exception.getMessage());
+		logInfo(request, FORBIDDEN, exception.getMessage());
 		return ApiResponse.error(exception.getCode());
 	}
 
@@ -51,7 +62,7 @@ public class GlobalExceptionHandler {
 	protected ApiResponse<Object> handleNotFoundException(
 			NotFoundException exception,
 			HttpServletRequest request) {
-		logInfo(request, HttpStatus.NOT_FOUND, exception.getMessage());
+		logInfo(request, NOT_FOUND, exception.getMessage());
 		return ApiResponse.error(exception.getCode());
 	}
 
@@ -60,7 +71,7 @@ public class GlobalExceptionHandler {
 	protected ApiResponse<Object> handleConflictException(
 			ConflictException exception,
 			HttpServletRequest request) {
-		logInfo(request, HttpStatus.CONFLICT, exception.getMessage());
+		logInfo(request, CONFLICT, exception.getMessage());
 		return ApiResponse.error(exception.getCode());
 	}
 
@@ -69,7 +80,7 @@ public class GlobalExceptionHandler {
 	protected ApiResponse<Object> handleInternalServerError(
 		InternalServerError exception,
 		HttpServletRequest request) {
-		logInfo(request, HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+		logInfo(request, INTERNAL_SERVER_ERROR, exception.getMessage());
 		return ApiResponse.error(exception.getCode());
 	}
 

--- a/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/utils/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 	PAGE_NOT_FOUND(NOT_FOUND, 1001, "요청한 페이지를 찾을 수 없습니다."),
 	UNAUTHORIZED_ACCESS(FORBIDDEN, 1002, "리소스 접근 권한이 없습니다."),
 	UNSUPPORTED_QUERY_VALUE(BAD_REQUEST, 1003, "지원하지 않는 쿼리스트링 값입니다."),
+	INVALID_DATA(BAD_REQUEST, 1004, "입력한 데이터가 유효하지 않습니다."),
 
 	//Not Found
 	USER_NOT_FOUND(NOT_FOUND, 1101, "사용자를 찾을 수 없습니다."),

--- a/haul-be/src/main/java/com/hansalchai/haul/user/controller/UsersController.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/controller/UsersController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -31,6 +30,7 @@ public class UsersController {
 
 	private final UsersService usersService;
 	private static final String V1_USERS_PATH = "/api/v1/users";
+	private static final String V2_USERS_PATH = "/api/v2/users";
 
 	@PostMapping(V1_USERS_PATH + "/sign-up")
 	public ResponseEntity<ApiResponse<Object>> signUp(@Valid @RequestBody CustomerSignUpDto signUpDto) {
@@ -57,5 +57,19 @@ public class UsersController {
 		AuthenticatedUser auth = (AuthenticatedUser)request.getAttribute(AUTHENTICATE_USER);
 		usersService.putProfile(profileUpdateDTO, auth.getUserId());
 		return ResponseEntity.ok(success(SuccessCode.GET_SUCCESS, null));
+	}
+
+	@PostMapping(V2_USERS_PATH + "/customers/sign-in")
+	public ResponseEntity<ApiResponse<UserLogin.ResponseDto>> customerSignInV2(
+		@Valid @RequestBody UserLogin.RequestDto requestDto) throws JsonProcessingException {
+		UserLogin.ResponseDto responseDto = usersService.customerSignInV2(requestDto);
+		return ResponseEntity.ok(success(SuccessCode.GET_SUCCESS, responseDto));
+	}
+
+	@PostMapping(V2_USERS_PATH + "/drivers/sign-in")
+	public ResponseEntity<ApiResponse<UserLogin.ResponseDto>> driverSignInV2(
+		@Valid @RequestBody UserLogin.RequestDto requestDto) throws JsonProcessingException {
+		UserLogin.ResponseDto responseDto = usersService.driverSignInV2(requestDto);
+		return ResponseEntity.ok(success(SuccessCode.GET_SUCCESS, responseDto));
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/user/dto/CustomerSignUpDto.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/dto/CustomerSignUpDto.java
@@ -3,7 +3,9 @@ package com.hansalchai.haul.user.dto;
 import com.hansalchai.haul.common.auth.constants.Role;
 import com.hansalchai.haul.user.entity.Users;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,16 +13,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CustomerSignUpDto {
 
-	@NotNull(message = "이름은 null일 수 없습니다.")
+	private static final String TEL_REGEX = "^(01[016789]|02|\\d{2,3})-?(\\d{3,4})-?(\\d{4})$";
+	private static final String EMAIL_REGEX = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}$";
+
+	@NotBlank(message = "이름은 null이나 공백일 수 없습니다.")
 	private String name;
 
 	@NotNull(message = "전화번호는 null일 수 없습니다.")
+	@Pattern(regexp = TEL_REGEX)
 	private String tel;
 
-	@NotNull(message = "비밀번호는 null일 수 없습니다.")
+	@NotBlank(message = "비밀번호는 공백일 수 없습니다.")
 	private String password;
 
 	@NotNull(message = "이메일은 null일 수 없습니다.")
+	@Pattern(regexp = EMAIL_REGEX)
 	private String email;
 
 	public CustomerSignUpDto(String name, String tel, String password, String email) {

--- a/haul-be/src/main/java/com/hansalchai/haul/user/repository/UsersRepository.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/repository/UsersRepository.java
@@ -12,4 +12,10 @@ public interface UsersRepository extends JpaRepository<Users, Long> {
 
 	@Query("select u from Users u where u.tel = :tel and u.role != 'GUEST'")
 	Optional<Users> findUserByTel(@Param("tel") String tel);
+
+	@Query("select u from Users u where u.tel = :tel and u.role = 'CUSTOMER'")
+	Optional<Users> findCustomerByTel(@Param("tel") String tel);
+
+	@Query("select u from Users u where u.tel = :tel and u.role = 'DRIVER'")
+	Optional<Users> findDriverByTel(@Param("tel") String tel);
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/user/service/UsersService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/user/service/UsersService.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.hansalchai.haul.common.auth.jwt.Jwt;
 import com.hansalchai.haul.common.auth.service.AuthService;
 import com.hansalchai.haul.common.exceptions.ConflictException;
-import com.hansalchai.haul.common.exceptions.ForbiddenException;
 import com.hansalchai.haul.common.exceptions.NotFoundException;
 import com.hansalchai.haul.common.exceptions.UnauthorizedException;
 import com.hansalchai.haul.user.dto.CustomerSignUpDto;
@@ -70,5 +69,33 @@ public class UsersService {
 		Users user = usersRepository.findById(userId)
 			.orElseThrow(() ->  new NotFoundException(USER_NOT_FOUND));
 		user.update(profileUpdateDTO.getPassword());
+	}
+
+	public UserLogin.ResponseDto customerSignInV2(UserLogin.RequestDto requestDto) throws JsonProcessingException {
+
+		Users user = usersRepository.findCustomerByTel(requestDto.getTel())
+			.orElseThrow(() -> new UnauthorizedException(UNREGISTERED_USER_ID));
+
+		if (!requestDto.getPassword().equals(user.getPassword())) {
+			throw new UnauthorizedException(INCORRECT_PASSWORD);
+		}
+
+		Jwt jwt = authService.createJwt(user);
+		user.updateRefreshToken(jwt.getRefreshToken());
+		return new UserLogin.ResponseDto(jwt, user.getName());
+	}
+
+	public UserLogin.ResponseDto driverSignInV2(UserLogin.RequestDto requestDto) throws JsonProcessingException {
+
+		Users user = usersRepository.findDriverByTel(requestDto.getTel())
+			.orElseThrow(() -> new UnauthorizedException(UNREGISTERED_USER_ID));
+
+		if (!requestDto.getPassword().equals(user.getPassword())) {
+			throw new UnauthorizedException(INCORRECT_PASSWORD);
+		}
+
+		Jwt jwt = authService.createJwt(user);
+		user.updateRefreshToken(jwt.getRefreshToken());
+		return new UserLogin.ResponseDto(jwt, user.getName());
 	}
 }


### PR DESCRIPTION
## 반영 브랜치
feat/#190-enhance-login -> BE_dev

## PR 요약
- 고객/기사 로그인 분리
- 전화번호, 이메일, 비밀번호 정규 표현식 추가

## PR 설명
**1. 고객/기사 로그인 api 분리**
기존 코드에선 고객 계정으로 기사 앱에 로그인할 수 있고 그 반대의 경우도 가능했다. 고객 계정으론 고객 앱에만 로그인할 수 있어야 하므로 고객/기사 로그인 api를 분리했다. 그리고 role을 확인하여 해당 권한을 가진 경우에만 로그인할 수 있도록 코드를 수정했다. (인가)

**2. 전화번호, 이메일, 비밀번호 정규 표현식 추가**
데이터의 정확성을 위해 회원가입시, 입력한 데이터가 유효성 검증에 통과해야 회원가입에 성공한다.

## ETC
- 추후 로그인 중복 코드 제거할 예정입니다.
- Close #190 
