### PR TITLE
Feat/#215 verson2 driver api

### DIFF
--- a/haul-driver-fe/src/repository/checkRepository.jsx
+++ b/haul-driver-fe/src/repository/checkRepository.jsx
@@ -1,7 +1,6 @@
 import { ErrorMessageMap } from "../data/GlobalVariable";
 import { getAccessToken, getCoordinate } from "../utils/localStorage";
 
-
 const apiKey = import.meta.env.VITE_API_KEY;
 
 export async function getDriverSummaryList({ page, keyword = "운송 전" }) {
@@ -63,7 +62,7 @@ export async function getDriverSummaryList({ page, keyword = "운송 전" }) {
 export async function orderStatusChage({ orderId }) {
   try {
     const userCoordinate = getCoordinate();
-    if(!userCoordinate.userLatitude) return { success: false, code: 99 };
+    if (!userCoordinate.userLatitude) return { success: false, code: 99 };
     const response = await fetch(`${apiKey}/api/v2/orders/status`, {
       method: "PATCH",
       headers: {

--- a/haul-driver-fe/src/repository/checkRepository.jsx
+++ b/haul-driver-fe/src/repository/checkRepository.jsx
@@ -63,6 +63,7 @@ export async function getDriverSummaryList({ page, keyword = "운송 전" }) {
 export async function orderStatusChage({ orderId }) {
   try {
     const userCoordinate = getCoordinate();
+    if(!userCoordinate.userLatitude) return { success: false, code: 99 };
     const response = await fetch(`${apiKey}/api/v2/orders/status`, {
       method: "PATCH",
       headers: {

--- a/haul-driver-fe/src/repository/checkRepository.jsx
+++ b/haul-driver-fe/src/repository/checkRepository.jsx
@@ -1,5 +1,6 @@
 import { ErrorMessageMap } from "../data/GlobalVariable";
-import { getAccessToken } from "../utils/localStorage";
+import { getAccessToken, getCoordinate } from "../utils/localStorage";
+
 
 const apiKey = import.meta.env.VITE_API_KEY;
 
@@ -61,13 +62,18 @@ export async function getDriverSummaryList({ page, keyword = "운송 전" }) {
 // 운송 상태 변경
 export async function orderStatusChage({ orderId }) {
   try {
-    const response = await fetch(`${apiKey}/api/v1/orders/status`, {
+    const userCoordinate = getCoordinate();
+    const response = await fetch(`${apiKey}/api/v2/orders/status`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${getAccessToken()}`
       },
-      body: JSON.stringify({ id: orderId })
+      body: JSON.stringify({
+        id: orderId,
+        latitude: userCoordinate.userLatitude,
+        longitude: userCoordinate.userLongitude
+      })
     });
     const data = await response.json();
     if (data.status === 200)

--- a/haul-driver-fe/src/repository/createRepository.jsx
+++ b/haul-driver-fe/src/repository/createRepository.jsx
@@ -83,7 +83,7 @@ export async function orderDetail({ orderId }) {
 //오더 승인 API 연결함수
 export async function orderApprove({ orderId }) {
   try {
-    const response = await fetch(`${apiKey}/api/v1/orders/approve`, {
+    const response = await fetch(`${apiKey}/api/v2/orders/approve`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",

--- a/haul-driver-fe/src/repository/userRepository.jsx
+++ b/haul-driver-fe/src/repository/userRepository.jsx
@@ -6,7 +6,7 @@ const apiKey = import.meta.env.VITE_API_KEY;
 
 export async function loginFun({ tel, password }) {
   try {
-    const response = await fetch(`${apiKey}/api/v1/users/sign-in`, {
+    const response = await fetch(`${apiKey}/api/v2/users/drivers/sign-in`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json"

--- a/haul-driver-fe/src/utils/localStorage.js
+++ b/haul-driver-fe/src/utils/localStorage.js
@@ -38,14 +38,14 @@ export function setCoordinate({ userLatitude, userLongitude }) {
   localStorage.setItem("userLongitude", userLongitude);
 }
 
-export function getCoordinate(){
-  return{
+export function getCoordinate() {
+  return {
     userLatitude: localStorage.getItem("userLatitude"),
-    userLongitude: localStorage.getItem("userLongitude"),
-  }
+    userLongitude: localStorage.getItem("userLongitude")
+  };
 }
 
-export function removeCoordinate(){
+export function removeCoordinate() {
   localStorage.removeItem("userLatitude");
   localStorage.removeItem("userLongitude");
 }

--- a/haul-driver-fe/src/utils/localStorage.js
+++ b/haul-driver-fe/src/utils/localStorage.js
@@ -32,3 +32,20 @@ export function logoutFun() {
   localStorage.removeItem("refreshToken");
   localStorage.removeItem("userName");
 }
+
+export function setCoordinate({ userLatitude, userLongitude }) {
+  localStorage.setItem("userLatitude", userLatitude);
+  localStorage.setItem("userLongitude", userLongitude);
+}
+
+export function getCoordinate(){
+  return{
+    userLatitude: localStorage.getItem("userLatitude"),
+    userLongitude: localStorage.getItem("userLongitude"),
+  }
+}
+
+export function removeCoordinate(){
+  localStorage.removeItem("userLatitude");
+  localStorage.removeItem("userLongitude");
+}

--- a/haul-driver-fe/src/views/Login/Login.jsx
+++ b/haul-driver-fe/src/views/Login/Login.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import MobileLayout from "../../components/MobileLayout/MobileLayout.jsx";
 import Typography from "../../components/Typhography/Typhography.jsx";
 import TypographySpan from "../../components/Typhography/TyphographySpan.jsx";
@@ -8,7 +8,6 @@ import Input from "../../components/Input/Input.jsx";
 import BottomButton from "../../components/Button/BottomButton.jsx";
 import FixedCenterBox from "../../components/FixedBox/FixedCenterBox.jsx";
 import { checkLoginAbled, loginBtnFun } from "./index.jsx";
-import { useNavigate } from "react-router-dom";
 
 const Login = () => {
   const tel = useRef("");

--- a/haul-driver-fe/src/views/Login/Login.jsx
+++ b/haul-driver-fe/src/views/Login/Login.jsx
@@ -8,20 +8,12 @@ import Input from "../../components/Input/Input.jsx";
 import BottomButton from "../../components/Button/BottomButton.jsx";
 import FixedCenterBox from "../../components/FixedBox/FixedCenterBox.jsx";
 import { checkLoginAbled, loginBtnFun } from "./index.jsx";
-import { isLoginFun } from "../../utils/localStorage.js";
 import { useNavigate } from "react-router-dom";
-import { UrlMap } from "../../data/GlobalVariable.js";
 
 const Login = () => {
-  const navigate = useNavigate();
   const tel = useRef("");
   const password = useRef("");
   const [isButtonDisabled, setButtonDisabled] = useState(true);
-
-  useEffect(() => {
-    const isLogin = isLoginFun();
-    if (isLogin) navigate(UrlMap.scheduleCreatePageUrl);
-  });
 
   return (
     <MobileLayout>

--- a/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckDetail/index.jsx
+++ b/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckDetail/index.jsx
@@ -32,14 +32,29 @@ export async function showDetailFun({ orderId, setOrderData, navigate }) {
 }
 
 export async function driveStartFun({ orderId, setDriverStatus, navigate }) {
-  const { success, code } = await orderStatusChage({
+  const { success, data, code } = await orderStatusChage({
     orderId: orderId
   });
   if (success) {
-    setDriverStatus("운송 중");
-    ToastMaker({ type: "success", children: "안전 운전 되세요." });
+    if (data.data.hasInProgressOrder) {
+      ToastMaker({
+        type: "error",
+        children: "한번에 한 내역만 하실 수 있어요."
+      });
+    } else if (!data.data.driverNearBy) {
+      ToastMaker({ type: "error", children: "300m이내에서 운송상태를 변경할 수 있어요." });
+    } else {
+      setDriverStatus("운송 중");
+      ToastMaker({ type: "success", children: "안전 운전 되세요." });
+    }
   } else {
     if (isTokenInvalid(code)) navigate(UrlMap.loginPageUrl);
+    if (code === 99) {
+      ToastMaker({
+        type: "error",
+        children: "위치 정보를 허용해주세요."
+      });
+    }
     if (code === 1103) {
       ToastMaker({
         type: "error",
@@ -64,15 +79,24 @@ export async function driveStartFun({ orderId, setDriverStatus, navigate }) {
 }
 
 export async function driveEndFun({ orderId, setDriverStatus, navigate }) {
-  //도착 로직
-  const { success, code } = await orderStatusChage({
+  const { success, data, code } = await orderStatusChage({
     orderId: orderId
   });
   if (success) {
-    setDriverStatus("운송 완료");
-    ToastMaker({ type: "success", children: "운행이 종료되었습니다." });
+    if (!data.data.driverNearBy) {
+      ToastMaker({ type: "error", children: "300m이내에서 운송상태를 변경할 수 있어요." });
+    } else {
+      setDriverStatus("운송 완료");
+      ToastMaker({ type: "success", children: "운행이 종료되었습니다." });
+    }
   } else {
     if (isTokenInvalid(code)) navigate(UrlMap.loginPageUrl);
+    if (code === 99) {
+      ToastMaker({
+        type: "error",
+        children: "위치 정보를 허용해주세요."
+      });
+    }
     if (code === 1103) {
       ToastMaker({
         type: "error",

--- a/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckDetail/index.jsx
+++ b/haul-driver-fe/src/views/ScheduleCheck/ScheduleCheckDetail/index.jsx
@@ -42,7 +42,10 @@ export async function driveStartFun({ orderId, setDriverStatus, navigate }) {
         children: "한번에 한 내역만 하실 수 있어요."
       });
     } else if (!data.data.driverNearBy) {
-      ToastMaker({ type: "error", children: "300m이내에서 운송상태를 변경할 수 있어요." });
+      ToastMaker({
+        type: "error",
+        children: "300m이내에서 운송상태를 변경할 수 있어요."
+      });
     } else {
       setDriverStatus("운송 중");
       ToastMaker({ type: "success", children: "안전 운전 되세요." });
@@ -84,7 +87,10 @@ export async function driveEndFun({ orderId, setDriverStatus, navigate }) {
   });
   if (success) {
     if (!data.data.driverNearBy) {
-      ToastMaker({ type: "error", children: "300m이내에서 운송상태를 변경할 수 있어요." });
+      ToastMaker({
+        type: "error",
+        children: "300m이내에서 운송상태를 변경할 수 있어요."
+      });
     } else {
       setDriverStatus("운송 완료");
       ToastMaker({ type: "success", children: "운행이 종료되었습니다." });

--- a/haul-driver-fe/src/views/Splash/Splash.jsx
+++ b/haul-driver-fe/src/views/Splash/Splash.jsx
@@ -74,13 +74,11 @@ const Splash = () => {
           },
           (error) => {
             ToastMaker({type:"error", children:"위치 정보를 허용해주세요."})
-            console.error("Error Code = " + error.code + " - " + error.message);
             reject(error);
           }
         );
       } else {
         ToastMaker({type:"error", children: "위치 정보를 허용할 수 없는 브라우저입니다."})
-        console.log("Geolocation is not supported by this browser.");
         reject(new Error("Geolocation is not supported by this browser."));
       }
     });

--- a/haul-driver-fe/src/views/Splash/Splash.jsx
+++ b/haul-driver-fe/src/views/Splash/Splash.jsx
@@ -6,6 +6,8 @@ import Typography from "../../components/Typhography/Typhography.jsx";
 import Loading from "../../assets/gifs/Loading.gif";
 import HaulCar from "../../assets/svgs/HaulCar.svg";
 import { UrlMap } from "../../data/GlobalVariable.js";
+import { setCoordinate } from "../../utils/localStorage.js";
+import ToastMaker from "../../components/Toast/ToastMaker.jsx";
 
 const SplashBox = styled.div`
   width: 100%;
@@ -63,10 +65,38 @@ const Splash = () => {
   };
 
   useEffect(() => {
-    animateText();
-    setTimeout(() => {
-      navigate(UrlMap.loginPageUrl);
-    }, animationDuration + delayTime);
+    const positionPromise = new Promise((resolve, reject) => {
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            setCoordinate({userLatitude: position.coords.latitude, userLongitude: position.coords.longitude});
+            resolve();
+          },
+          (error) => {
+            ToastMaker({type:"error", children:"위치 정보를 허용해주세요."})
+            console.error("Error Code = " + error.code + " - " + error.message);
+            reject(error);
+          }
+        );
+      } else {
+        ToastMaker({type:"error", children: "위치 정보를 허용할 수 없는 브라우저입니다."})
+        console.log("Geolocation is not supported by this browser.");
+        reject(new Error("Geolocation is not supported by this browser."));
+      }
+    });
+
+    const timeoutPromise = new Promise((resolve) => {
+      animateText();
+      setTimeout(resolve, animationDuration + delayTime);
+    });
+
+    Promise.all([positionPromise, timeoutPromise])
+      .then(() => {
+        navigate(UrlMap.loginPageUrl);
+      })
+      .catch((error) => {
+        console.error(error);
+      });
   }, []);
 
   return (

--- a/haul-driver-fe/src/views/Splash/Splash.jsx
+++ b/haul-driver-fe/src/views/Splash/Splash.jsx
@@ -68,22 +68,31 @@ const Splash = () => {
     const positionPromise = new Promise((resolve, reject) => {
       if (navigator.geolocation) {
         navigator.geolocation.getCurrentPosition(
-          (position) => {
-            setCoordinate({userLatitude: position.coords.latitude, userLongitude: position.coords.longitude});
+          position => {
+            setCoordinate({
+              userLatitude: position.coords.latitude,
+              userLongitude: position.coords.longitude
+            });
             resolve();
           },
-          (error) => {
-            ToastMaker({type:"error", children:"위치 정보를 허용해주세요."})
+          error => {
+            ToastMaker({
+              type: "error",
+              children: "위치 정보를 허용해주세요."
+            });
             reject(error);
           }
         );
       } else {
-        ToastMaker({type:"error", children: "위치 정보를 허용할 수 없는 브라우저입니다."})
+        ToastMaker({
+          type: "error",
+          children: "위치 정보를 허용할 수 없는 브라우저입니다."
+        });
         reject(new Error("Geolocation is not supported by this browser."));
       }
     });
 
-    const timeoutPromise = new Promise((resolve) => {
+    const timeoutPromise = new Promise(resolve => {
       animateText();
       setTimeout(resolve, animationDuration + delayTime);
     });
@@ -92,7 +101,7 @@ const Splash = () => {
       .then(() => {
         navigate(UrlMap.loginPageUrl);
       })
-      .catch((error) => {
+      .catch(error => {
         console.error(error);
       });
   }, []);


### PR DESCRIPTION
## 반영 브랜치
feat/#215-VERSON2-driver-API -> FE_Driver_dev

## PR 요약
- 기사 로그인 API Version2 적용
- 기사 오더 승인 API Version2 적용
- 기사 상태 변경 API Version2 적용
- 초기 렌더링 페이지에서 기사님 위치 가져오기 연결 및 저장

## PR 설명
- 기사 로그인 API Version2 적용
Version2 기사 로그인 API 함수 이름을 변경했습니다. 

- 기사 오더 승인 API Version2 적용
오더 승인도 마찬가지로 Version2에서 바뀐 URL을 코드에서 변경했습니다. 

- 기사 상태 변경 API Version2 적용
- 초기 스플래쉬 페이지에서 기사님 위치 가져오기 연결 및 저장
경,위도를 스플래쉬 페이지에서 가져오게 하고, 이를 기사 상태 변경 API Version2에 적용함에 따라 기능을 구현하였습니다. 
* 문제 상황
처음에는 Status API를 호출할때 위치정보를 가져오는데 이때 시간이 너무 걸려 사용성이 떨어진다고 판단했습니다.
그래서 이를 해결하기 위해 초기 스플래쉬 페이지에서 드는 시간에 이 위치정보를 가져오도록 하여 Status변경할때는 위치 정보를 가져오는 시간을 감축시켰습니다. 