### PR TITLE
[fix] 기사 앱 발견한 오류 수정

### DIFF
--- a/haul-driver-fe/src/components/DetailInfo/DetailInfo.jsx
+++ b/haul-driver-fe/src/components/DetailInfo/DetailInfo.jsx
@@ -61,7 +61,7 @@ const DetailInfo = ({
   function changeTime(time) {
     if (time >= 1) {
       // 1시간 이상일 경우 소수점을 다 짤라서 반환
-      return Math.floor(time);
+      return time.toFixed(1);
     } else {
       // 1시간 미만일 경우 분으로 변환하여 소수점을 다 짤라서 반환
       return Math.floor(time * 60);

--- a/haul-driver-fe/src/components/DetailInfo/DetailInfo.jsx
+++ b/haul-driver-fe/src/components/DetailInfo/DetailInfo.jsx
@@ -103,8 +103,8 @@ const DetailInfo = ({
                 {dstName}
               </Typography>
               <Margin height="4px" />
-
               <Typography font="semiBold12">{dstAddress}</Typography>
+              {!dstName && <Margin height="8px" />}
             </PlaceInfo>
           </Flex>
         </Flex>

--- a/haul-driver-fe/src/components/HaulInfoBox/HaulInfoBox.jsx
+++ b/haul-driver-fe/src/components/HaulInfoBox/HaulInfoBox.jsx
@@ -80,7 +80,7 @@ const HaulInfoBox = ({
             <Margin height="4px" />
             <Typography font="medium12">{srcAddres}</Typography>
             <Typography font="medium12" color="grayText">
-              {srcName}, {srcDetailAddress}
+              {srcName && `${srcName}, `} {srcDetailAddress}
             </Typography>
           </Flex>
         </Flex>
@@ -95,7 +95,7 @@ const HaulInfoBox = ({
             <Margin height="4px" />
             <Typography font="medium12">{dstAddress}</Typography>
             <Typography font="medium12" color="grayText">
-              {dstName}, {dstDetailAddress}
+              {dstName && `${dstName}, `} {dstDetailAddress}
             </Typography>
           </Flex>
         </Flex>


### PR DESCRIPTION
## 반영 브랜치
feature/#216-driverv2 -> BE_dev

## PR 요약
- 예상 시간이 1시간 이상일 때, 시간 단위의 소수점 아래 자리가 나오지 않던 문제 수정
   - 입력 : 1.314
   - 예상 : 1.3
   - 실제 : 1
- 건물명이 없어도 건물명 반점이 출력되던 문제 수정
   - 입력 : 출발지건물명: "", 출발지주소: "서울 동작로 1"
   - 예상 : 서울 동작로 1
   - 실제 : , 서울 동작로
- 도착지 이름이 없으면 도착지 주소를 8px 올리도록 변경