### PR TITLE
Hotfix 필터, 인터셉터를 통과하지 않는 url 리스트 수정

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/JwtValidationFilter.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/JwtValidationFilter.java
@@ -34,7 +34,7 @@ public class JwtValidationFilter implements Filter {
 	private final String[] whiteListUris
 		= new String[] {"/api/v1/users/sign-in", "/api/v1/users/sign-up", "/auth/refresh/token",
 		"/api/v2/users/customers/sign-in", "/api/v2/users/drivers/sign-in",
-		"*/h2-console*", "/swagger-ui/**", "*/api-docs*", "/api/v1/reservations/guest*"};
+		"*/h2-console*", "/swagger-ui/**", "*/api-docs*", "/api/v1/reservations/guest", "/api/v1/reservations/guest/**"};
 
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws

--- a/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/WebAuthConfig.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/auth/config/WebAuthConfig.java
@@ -29,8 +29,8 @@ public class WebAuthConfig implements WebMvcConfigurer {
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(new UserAuthorizationInterceptor())
 			.order(1)
-			.excludePathPatterns("/api/v1/users/sign-in, /api/v1/users/sign-up", "/api/v2/users/customers/sign-in",
-				"/api/v2/users/drivers/sign-in", "/api/v1/reservations/guest*")
+			.excludePathPatterns("/api/v1/users/sign-in", "/api/v1/users/sign-up", "/api/v2/users/customers/sign-in",
+				"/api/v2/users/drivers/sign-in", "/api/v1/reservations/guest", "/api/v1/reservations/guest/**")
 			.excludePathPatterns("*/h2-console*", "/css/**", "/*.ico", "/error");
 	}
 

--- a/haul-be/src/main/java/com/hansalchai/haul/common/config/WebConfig.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/config/WebConfig.java
@@ -14,7 +14,7 @@ public class WebConfig implements WebMvcConfigurer {
 		registry.addMapping("/**")
 			.allowedOrigins("http://43.201.240.238:5174", "http://43.201.240.238:5173", "https://haul.pages.dev",
 				"http://localhost:5173", "http://localhost:4173", "http://localhost:5174"
-				, "http://hyundai-haul.com/", "http://driver.hyundai-haul.com/", "https://hyundai-haul.com/",
+				, "http://client.hyundai-haul.com/", "http://driver.hyundai-haul.com/", "https://client.hyundai-haul.com/",
 				"https://driver.hyundai-haul.com/")
 			.allowedMethods("*")
 			.allowedHeaders("*")


### PR DESCRIPTION
## 반영 브랜치
hotfix/modify-interceptor-excludePathPatters -> BE_dev

## PR 요약
- 인터셉터 제외 url 리스트에 회원가입, 로그인 url이 합쳐져있던 것을 발견하여 분리함
- 필터 및 인터셉터 제외 url 리스트에 게스트 url 추가