### PR TITLE
Add/#244 비회원 예약 확정 메시지 전송 기능 추가 및 기사 배정 알림 메시지의 주석 해제 

### DIFF
--- a/haul-be/src/main/java/com/hansalchai/haul/common/config/SmsUtil.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/common/config/SmsUtil.java
@@ -32,8 +32,20 @@ public class SmsUtil {
 		messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecretKey, "https://api.coolsms.co.kr");
 	}
 
-	// 단일 메시지 발송
-	public SingleMessageSentResponse send(String to, String reservationNumber) {
+	// 비회원 예약 확정 메시지 발송
+	public SingleMessageSentResponse sendReservationConfirmNotification(String to, String reservationNumber) {
+		Message message = new Message();
+		message.setFrom(from);
+		message.setTo(to);
+		message.setText("예약이 확정되었습니다.\n" + "예약번호 : " + reservationNumber);
+
+		SingleMessageSentResponse response = this.messageService.sendOne(new SingleMessageSendingRequest(message));
+		log.info("sms 전송 내역 : {}", response);
+		return response;
+	}
+
+	// 기사 배정 메시지 발송
+	public SingleMessageSentResponse sendAssignNotification(String to, String reservationNumber) {
 		Message message = new Message();
 		message.setFrom(from);
 		message.setTo(to);

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -33,7 +33,6 @@ import com.hansalchai.haul.common.utils.SidoGraph;
 import com.hansalchai.haul.order.constants.OrderFilter;
 import com.hansalchai.haul.order.constants.OrderFilterV2;
 import com.hansalchai.haul.order.constants.OrderStatusCategory;
-import com.hansalchai.haul.order.dto.OrderResponse.*;
 import com.hansalchai.haul.order.dto.OrderResponse.OrderDTO.OrderInfoDTO;
 import com.hansalchai.haul.owner.entity.Owner;
 import com.hansalchai.haul.owner.repository.OwnerRepository;
@@ -87,17 +86,17 @@ public class OrderService {
 		// 예약에 기사 배정 정보 저장, 운송 상태를 '운송 전'으로 변경
 		Owner owner = findOwner(userId);
 		assignDriverToReservation(reservation, owner);
-		// sendAssignNotificationToCustomer(reservation);
+		sendAssignNotification(reservation);
 	}
 
 	private static boolean isAlreadyAssignedDriverExist(Reservation reservation) {
 		return reservation.getOwner() != null;
 	}
 
-	private void sendAssignNotificationToCustomer(Reservation reservation) {
+	private void sendAssignNotification(Reservation reservation) {
 		String customerTel = reservation.getUser().getTel();
 		String reservationNumber = reservation.getNumber();
-		smsUtil.send(customerTel, reservationNumber);
+		smsUtil.sendAssignNotification(customerTel, reservationNumber);
 	}
 
 	private static void assignDriverToReservation(Reservation reservation, Owner owner) {
@@ -121,7 +120,7 @@ public class OrderService {
 		}
 
 		assignDriverToReservation(reservation, owner);
-		// sendAssignNotificationToCustomer(reservation);
+		sendAssignNotification(reservation);
 	}
 
 	/*

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/service/ReservationService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/service/ReservationService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import com.hansalchai.haul.car.entity.Car;
 import com.hansalchai.haul.common.auth.constants.Role;
+import com.hansalchai.haul.common.config.SmsUtil;
 import com.hansalchai.haul.common.exceptions.ForbiddenException;
 import com.hansalchai.haul.common.exceptions.NotFoundException;
 import com.hansalchai.haul.common.utils.CarCategorySelector;
@@ -45,7 +46,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Service
 public class ReservationService {
+
 	private final S3Util s3Util;
+	private final SmsUtil smsUtil;
 	private final KakaoMap kakaoMap;
 	private final ReservationRepository reservationRepository;
 	private final UsersRepository usersRepository;
@@ -192,6 +195,7 @@ public class ReservationService {
 		exceptionInvalidReservationStateChange(reservation);
 
 		changeReservationStatus(reservation);
+		smsUtil.sendReservationConfirmNotification(reservation.getUser().getTel(), reservation.getNumber());
 	}
 
 	private String generateUniqueReservationNumber() {


### PR DESCRIPTION
## 반영 브랜치
add/#244 send guest reservation notification -> BE_dev

## PR 설명
- 비회원은 예약이 확정되면 예약을 확인할 수 있도록 메시지를 보내는 기능을 추가했다
- 기존에 주석처리 해놓았던 기사 배정 알림 메시지 기능을 활성화했다

## ETC
Close #244 
