### PR TITLE
Feat 동시성 문제 개선

### DIFF
--- a/haul-be/src/main/generated/com/hansalchai/haul/reservation/entity/QReservation.java
+++ b/haul-be/src/main/generated/com/hansalchai/haul/reservation/entity/QReservation.java
@@ -67,6 +67,8 @@ public class QReservation extends EntityPathBase<Reservation> {
 
     public final com.hansalchai.haul.user.entity.QUsers user;
 
+    public final NumberPath<Long> version = createNumber("version", Long.class);
+
     public QReservation(String variable) {
         this(Reservation.class, forVariable(variable), INITS);
     }

--- a/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/controller/OrderController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.hansalchai.haul.common.auth.anotation.LoggedInUser;
 import com.hansalchai.haul.common.auth.dto.AuthenticatedUser;
 import com.hansalchai.haul.common.utils.ApiResponse;
-import com.hansalchai.haul.order.dto.OrderResponse.*;
+import com.hansalchai.haul.order.facade.OptimisticLockOrderFacade;
 import com.hansalchai.haul.order.service.OrderService;
 
 import jakarta.validation.Valid;
@@ -28,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class OrderController {
 
 	private final OrderService orderService;
+	private final OptimisticLockOrderFacade optimisticLockOrderFacade;
 	private static final String V1_ORDERS_PATH = "/api/v1/orders";
 	private static final String V2_ORDERS_PATH = "/api/v2/orders";
 
@@ -96,8 +97,8 @@ public class OrderController {
 	@PatchMapping(V2_ORDERS_PATH + "/approve")
 	public ResponseEntity<ApiResponse<Object>> approveOrderV2(
 		@LoggedInUser AuthenticatedUser authenticatedUser,
-		@Valid @RequestBody ApproveRequestDto approveRequestDto) {
-		orderService.approveV2(authenticatedUser.getUserId(), approveRequestDto);
+		@Valid @RequestBody ApproveRequestDto approveRequestDto) throws InterruptedException {
+		optimisticLockOrderFacade.approveV2(authenticatedUser.getUserId(), approveRequestDto);
 		return ResponseEntity.ok(success(GET_SUCCESS, null));
 	}
 

--- a/haul-be/src/main/java/com/hansalchai/haul/order/facade/OptimisticLockOrderFacade.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/facade/OptimisticLockOrderFacade.java
@@ -1,0 +1,34 @@
+package com.hansalchai.haul.order.facade;
+
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+import com.hansalchai.haul.common.exceptions.ConflictException;
+import com.hansalchai.haul.order.dto.OrderRequest;
+import com.hansalchai.haul.order.service.OrderService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OptimisticLockOrderFacade {
+
+	private final OrderService orderService;
+
+	public void approveV2(Long userId, OrderRequest.ApproveRequestDto approveRequestDto) throws InterruptedException {
+		while (true) {
+			try {
+				orderService.approveV2(userId, approveRequestDto);
+				break;
+			} catch (ConflictException e) {
+				log.error("[ConflictException] {}", e.getMessage());
+				break;
+			} catch (ObjectOptimisticLockingFailureException e) {
+				log.error(e.getMessage());
+				Thread.sleep(50);
+			}
+		}
+	}
+}

--- a/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/order/service/OrderService.java
@@ -33,7 +33,6 @@ import com.hansalchai.haul.common.utils.SidoGraph;
 import com.hansalchai.haul.order.constants.OrderFilter;
 import com.hansalchai.haul.order.constants.OrderFilterV2;
 import com.hansalchai.haul.order.constants.OrderStatusCategory;
-import com.hansalchai.haul.order.dto.OrderResponse.*;
 import com.hansalchai.haul.order.dto.OrderResponse.OrderDTO.OrderInfoDTO;
 import com.hansalchai.haul.owner.entity.Owner;
 import com.hansalchai.haul.owner.repository.OwnerRepository;
@@ -87,7 +86,7 @@ public class OrderService {
 		// 예약에 기사 배정 정보 저장, 운송 상태를 '운송 전'으로 변경
 		Owner owner = findOwner(userId);
 		assignDriverToReservation(reservation, owner);
-		// sendAssignNotificationToCustomer(reservation);
+		sendAssignNotificationToCustomer(reservation);
 	}
 
 	private static boolean isAlreadyAssignedDriverExist(Reservation reservation) {
@@ -108,7 +107,7 @@ public class OrderService {
 
 	public void approveV2(Long userId, ApproveRequestDto approveRequestDto) {
 
-		Reservation reservation = reservationRepository.findByIdWithPessimisticLock(approveRequestDto.getId())
+		Reservation reservation = reservationRepository.findByIdWithOptimisticLock(approveRequestDto.getId())
 			.orElseThrow(() -> new NotFoundException(RESERVATION_NOT_FOUND));
 
 		if (isAlreadyAssignedDriverExist(reservation)) {
@@ -121,7 +120,7 @@ public class OrderService {
 		}
 
 		assignDriverToReservation(reservation, owner);
-		// sendAssignNotificationToCustomer(reservation);
+		sendAssignNotificationToCustomer(reservation);
 	}
 
 	/*

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/dto/ReservationRequest.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/dto/ReservationRequest.java
@@ -226,6 +226,7 @@ public class ReservationRequest {
 		@Getter
 		@Setter
 		@ToString
+		@NoArgsConstructor
 		public static class SourceDTO {
 			@NotNull(message = "출발지 이름은 Null 일 수 없다.")
 			private String name;
@@ -271,6 +272,7 @@ public class ReservationRequest {
 		@Getter
 		@Setter
 		@ToString
+		@NoArgsConstructor
 		public static class DestinationDTO {
 			@NotNull(message = "도착지 이름은 Null 일 수 없다.")
 			private String name;
@@ -316,6 +318,7 @@ public class ReservationRequest {
 		@Getter
 		@Setter
 		@ToString
+		@NoArgsConstructor
 		public static class CargoDTO {
 			@NotNull(message = "화물 가로는 Null 일 수 없다.")
 			@Range(min = 0, max = 1000, message = "화물 가로는 10m를 넘을 수 없다.")
@@ -354,6 +357,7 @@ public class ReservationRequest {
 		@Getter
 		@Setter
 		@ToString
+		@NoArgsConstructor
 		public static class CargoOptionDTO {
 			@JsonProperty("refrigerated")
 			@NotNull(message = "냉장여부는 Null 일 수 없다.")
@@ -393,6 +397,7 @@ public class ReservationRequest {
 		@Getter
 		@Setter
 		@ToString
+		@NoArgsConstructor
 		public static class UserInfoDTO {
 			@NotNull(message = "비회원 유저 이름은 Null일 수 없다.")
 			private String name;
@@ -406,6 +411,5 @@ public class ReservationRequest {
 				this.tel = tel;
 			}
 		}
-
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/entity/Reservation.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/entity/Reservation.java
@@ -8,7 +8,9 @@ import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.validator.constraints.Range;
 
 import com.hansalchai.haul.car.entity.Car;
+import com.hansalchai.haul.common.exceptions.ConflictException;
 import com.hansalchai.haul.common.utils.BaseTime;
+import com.hansalchai.haul.common.utils.ErrorCode;
 import com.hansalchai.haul.common.utils.ReservationNumberGenerator;
 import com.hansalchai.haul.owner.entity.Owner;
 import com.hansalchai.haul.user.entity.Users;
@@ -23,6 +25,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -81,6 +84,9 @@ public class Reservation extends BaseTime {
 	@Column(nullable = false)
 	private double distance;
 
+	@Version
+	private Long version;
+
 	@Builder
 	public Reservation(Long reservationId, Users user, Owner owner, Cargo cargo, CargoOption cargoOption, Source source,
 		Destination destination, Transport transport, Car car, String number, LocalDate date, LocalTime time, int count,
@@ -122,6 +128,10 @@ public class Reservation extends BaseTime {
 	}
 
 	public void setDriver(Owner owner) {
-		this.owner = owner;
+		if (this.owner == null) {
+			this.owner = owner;
+			return;
+		}
+		throw new ConflictException(ErrorCode.ALREADY_ASSIGNED_DRIVER);
 	}
 }

--- a/haul-be/src/main/java/com/hansalchai/haul/reservation/repository/ReservationRepository.java
+++ b/haul-be/src/main/java/com/hansalchai/haul/reservation/repository/ReservationRepository.java
@@ -75,10 +75,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	@Query(value = "select r from Reservation r where r.owner.user.userId = :userId and r.transport.transportStatus = 'IN_PROGRESS'")
 	List<Reservation> findInProgressReservationByUserId(@Param("userId") Long id);
 
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Lock(LockModeType.OPTIMISTIC)
 	@Query("select r "
 		+ "from Reservation r "
-		+ "join fetch r.transport "
 		+ "where r.id = :id")
-	Optional<Reservation> findByIdWithPessimisticLock(@Param("id") Long id);
+	Optional<Reservation> findByIdWithOptimisticLock(@Param("id") Long id);
 }

--- a/haul-be/src/test/java/com/hansalchai/haul/order/service/OrderServiceUnitTest.java
+++ b/haul-be/src/test/java/com/hansalchai/haul/order/service/OrderServiceUnitTest.java
@@ -114,7 +114,7 @@ class OrderServiceUnitTest {
 		List<Reservation> reservations = createReservationsForApproveTest(owner);
 
 		given(ownerRepository.findByUserId(userId)).willReturn(Optional.of(owner));
-		given(reservationRepository.findByIdWithPessimisticLock(reservationId)).willReturn(Optional.of(newReservation));
+		given(reservationRepository.findByIdWithOptimisticLock(reservationId)).willReturn(Optional.of(newReservation));
 		given(reservationRepository.findScheduleOfDriver(ownerId,
 			LocalDate.of(2024, 2, 19),
 			LocalDate.of(2024, 2, 20))).willReturn(reservations);
@@ -150,7 +150,7 @@ class OrderServiceUnitTest {
 		List<Reservation> reservations = createReservationsForApproveTest(owner);
 
 		given(ownerRepository.findByUserId(userId)).willReturn(Optional.of(owner));
-		given(reservationRepository.findByIdWithPessimisticLock(reservationId)).willReturn(Optional.of(newReservation));
+		given(reservationRepository.findByIdWithOptimisticLock(reservationId)).willReturn(Optional.of(newReservation));
 		given(reservationRepository.findScheduleOfDriver(ownerId,
 			LocalDate.of(2024, 2, 19),
 			LocalDate.of(2024, 2, 20))).willReturn(reservations);

--- a/haul-be/src/test/java/com/hansalchai/haul/reservation/ReservationIntegrationTest.java
+++ b/haul-be/src/test/java/com/hansalchai/haul/reservation/ReservationIntegrationTest.java
@@ -52,8 +52,10 @@ public class ReservationIntegrationTest {
 
 	@Autowired
 	private ReservationService reservationService;
+
 	@Autowired
 	private UsersRepository usersRepository;
+
 	private MockMvc mvc;
 
 	@BeforeEach
@@ -91,7 +93,7 @@ public class ReservationIntegrationTest {
 	@DisplayName("MVC - 비회원은 화물차를 예약할 수 있습니다.")
 	void guestReservationMVCTest() throws Exception {
 		// given
-		ReservationRequest.CreateReservationDTO createReservationDTO = makeDummyReservationRequestDTO();
+		ReservationRequest.CreateReservationGuestDTO createReservationDTO = makeDummyReservationRequestGuestDTO();
 
 		String jsonContent = om.writeValueAsString(createReservationDTO);
 		logger.info(jsonContent);


### PR DESCRIPTION
## 반영 브랜치
feat/optimistic lock -> BE_dev

## PR 요약
1. 오더 승인 동시성 문제 해결에 사용하는 락 변경
2. 비회원 예약 테스트 수정

## PR 설명
1. 기존 코드는 오더 승인 요청의 충돌이 많이 일어날 것으로 예상해 비관적 락을 적용했습니다. 그러나 오더를 승인하는 화물 기사(사용자)는 제한적입니다. 따라서 동시 요청이 많이 발생하지 않을 것으로 예상하여 낙관적 락으로 동시 요청을 제어하도록 수정했습니다
2. ReservationTest의 비회원 예약 테스트를 위한 데이터 생성에 회원 데이터 생성이 아닌 비회원 데이터 생성 메서드를 사용하도록 수정했습니다.
